### PR TITLE
Add CSRF protection and async prayer notifications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,6 @@ dependencies = [
     "werkzeug>=3.0.6",
     "flask-sse>=1.0.0",
     "redis>=5.2.0",
+    "flask-wtf>=1.2.1",
+    "rq>=1.16.2",
 ]

--- a/routes/donations.py
+++ b/routes/donations.py
@@ -2,6 +2,7 @@ from flask import Blueprint, render_template, request, flash, redirect, url_for,
 from models import Donation
 from app import db
 from sqlalchemy.exc import SQLAlchemyError
+from decimal import Decimal, InvalidOperation
 import uuid
 import json
 from datetime import datetime
@@ -32,10 +33,10 @@ def process_donation():
 
         # Validate amount
         try:
-            amount = float(amount)
+            amount = Decimal(amount)
             if amount <= 0:
-                raise ValueError("Amount must be positive")
-        except ValueError:
+                raise InvalidOperation("Amount must be positive")
+        except (InvalidOperation, ValueError):
             flash('Please enter a valid donation amount.', 'danger')
             return redirect(url_for('donations.donate'))
 
@@ -85,7 +86,7 @@ def process_donation():
                 }
                 
                 payload = {
-                    'amount': int(amount * 100),  # Paystack expects amount in kobo
+                    'amount': int((amount * 100).to_integral_value()),  # Paystack expects amount in kobo
                     'currency': 'NGN',
                     'email': email,
                     'reference': reference,

--- a/routes/prayers.py
+++ b/routes/prayers.py
@@ -1,8 +1,7 @@
 from flask import Blueprint, render_template, request, flash, redirect, url_for, current_app
-from flask_login import login_required
-from app import db, mail
+from app import db, task_queue
 from models import PrayerRequest, User
-from flask_mail import Message
+from tasks import send_prayer_notification
 
 prayers_bp = Blueprint('prayers', __name__)
 
@@ -11,36 +10,6 @@ def prayers():
     public_prayers = PrayerRequest.query.filter_by(is_public=True).order_by(PrayerRequest.created_at.desc()).all()
     return render_template('prayers.html', prayers=public_prayers)
 
-def send_prayer_notification(prayer_request):
-    try:
-        # Get all admin users to notify
-        admin_users = User.query.filter_by(is_admin=True).all()
-        
-        if not admin_users:
-            current_app.logger.warning("No admin users found to notify about prayer request")
-            return
-        
-        subject = "New Prayer Request Received"
-        body = f"""
-A new prayer request has been submitted:
-
-From: {prayer_request.name}
-Email: {prayer_request.email}
-Request: {prayer_request.request}
-Public: {"Yes" if prayer_request.is_public else "No"}
-Submitted: {prayer_request.created_at.strftime('%B %d, %Y %I:%M %p')}
-        """
-        
-        msg = Message(
-            subject=subject,
-            recipients=[admin.email for admin in admin_users],
-            body=body
-        )
-        
-        mail.send(msg)
-        current_app.logger.info(f"Prayer request notification sent to {len(admin_users)} admin(s)")
-    except Exception as e:
-        current_app.logger.error(f"Failed to send prayer request notification: {str(e)}")
 
 @prayers_bp.route('/prayers/submit', methods=['POST'])
 def submit_prayer():
@@ -65,7 +34,7 @@ def submit_prayer():
         db.session.commit()
         
         # Send email notification to admins
-        send_prayer_notification(new_prayer)
+        task_queue.enqueue(send_prayer_notification, new_prayer.id)
         
         flash('Prayer request submitted successfully', 'success')
         return redirect(url_for('prayers.prayers'))

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,36 @@
+from flask_mail import Message
+from models import PrayerRequest, User
+
+def send_prayer_notification(prayer_request_id: int) -> None:
+    from app import create_app, mail, db
+    from flask import current_app
+
+    """Background task to send prayer notification emails to admins."""
+    app = create_app()
+    with app.app_context():
+        prayer_request = PrayerRequest.query.get(prayer_request_id)
+        if not prayer_request:
+            current_app.logger.error("Prayer request not found")
+            return
+
+        admin_users = User.query.filter_by(is_admin=True).all()
+        if not admin_users:
+            current_app.logger.warning("No admin users found to notify about prayer request")
+            return
+
+        subject = "New Prayer Request Received"
+        body = f"""
+A new prayer request has been submitted:
+
+From: {prayer_request.name}
+Email: {prayer_request.email}
+Request: {prayer_request.request}
+Public: {'Yes' if prayer_request.is_public else 'No'}
+Submitted: {prayer_request.created_at.strftime('%B %d, %Y %I:%M %p')}
+"""
+        msg = Message(subject=subject,
+                      recipients=[admin.email for admin in admin_users],
+                      body=body)
+        mail.send(msg)
+        current_app.logger.info(
+            f"Prayer request notification sent to {len(admin_users)} admin(s)")

--- a/templates/admin/event_form.html
+++ b/templates/admin/event_form.html
@@ -20,6 +20,7 @@
 <div class="card">
     <div class="card-body">
         <form method="POST" class="needs-validation" novalidate>
+    {{ csrf_token() }}
             <div class="mb-3">
                 <label for="title" class="form-label">Event Title</label>
                 <input type="text" class="form-control" id="title" name="title" 

--- a/templates/admin/events.html
+++ b/templates/admin/events.html
@@ -62,6 +62,7 @@
                                         <form action="{{ url_for('admin.delete_event', event_id=event.id) }}" 
                                               method="POST" class="d-inline"
                                               onsubmit="return confirm('Are you sure you want to delete this event?');">
+    {{ csrf_token() }}
                                             <button type="submit" class="btn btn-sm btn-outline-danger" 
                                                     title="Delete">
                                                 <i class="bi bi-trash"></i>

--- a/templates/admin/gallery.html
+++ b/templates/admin/gallery.html
@@ -36,6 +36,7 @@
                     <form action="{{ url_for('admin.delete_image', image_id=image.id) }}" 
                           method="POST" class="d-inline"
                           onsubmit="return confirm('Are you sure you want to delete this image?');">
+    {{ csrf_token() }}
                         <button type="submit" class="btn btn-sm btn-outline-danger">
                             <i class="bi bi-trash"></i> Delete
                         </button>
@@ -56,6 +57,7 @@
             </div>
             <div class="modal-body">
                 <form action="{{ url_for('admin.upload_image') }}" method="POST" enctype="multipart/form-data">
+    {{ csrf_token() }}
                     <div class="mb-3">
                         <label for="image" class="form-label">Choose Image</label>
                         <input type="file" class="form-control" id="image" name="image" accept="image/*" required>

--- a/templates/admin/prayers.html
+++ b/templates/admin/prayers.html
@@ -47,6 +47,7 @@
                                     </button>
                                     <form action="{{ url_for('admin.toggle_prayer_visibility', prayer_id=prayer.id) }}" 
                                           method="POST" class="d-inline">
+    {{ csrf_token() }}
                                         <button type="submit" class="btn btn-sm btn-outline-warning">
                                             <i class="bi bi-{% if prayer.is_public %}eye-slash{% else %}eye{% endif %}"></i>
                                         </button>
@@ -54,6 +55,7 @@
                                     <form action="{{ url_for('admin.delete_prayer', prayer_id=prayer.id) }}" 
                                           method="POST" class="d-inline"
                                           onsubmit="return confirm('Are you sure you want to delete this prayer request?');">
+    {{ csrf_token() }}
                                         <button type="submit" class="btn btn-sm btn-outline-danger">
                                             <i class="bi bi-trash"></i>
                                         </button>

--- a/templates/admin/sermon_form.html
+++ b/templates/admin/sermon_form.html
@@ -18,6 +18,7 @@
         <div class="card">
             <div class="card-body">
                 <form method="POST">
+    {{ csrf_token() }}
                     <div class="mb-3">
                         <label for="title" class="form-label">Title</label>
                         <input type="text" class="form-control" id="title" name="title" 

--- a/templates/admin/sermons.html
+++ b/templates/admin/sermons.html
@@ -57,6 +57,7 @@
                                     <form action="{{ url_for('admin.delete_sermon', sermon_id=sermon.id) }}" 
                                           method="POST" class="d-inline"
                                           onsubmit="return confirm('Are you sure you want to delete this sermon?');">
+    {{ csrf_token() }}
                                         <button type="submit" class="btn btn-sm btn-outline-danger">
                                             <i class="bi bi-trash"></i>
                                         </button>

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -21,6 +21,7 @@
             </div>
             <div class="card-body">
                 <form method="POST" enctype="multipart/form-data" id="settingsForm">
+    {{ csrf_token() }}
                     <div class="mb-3">
                         <label for="business_name" class="form-label">Business Name</label>
                         <input type="text" class="form-control" id="business_name" name="business_name" 

--- a/templates/admin/user_form.html
+++ b/templates/admin/user_form.html
@@ -18,6 +18,7 @@
         <div class="card">
             <div class="card-body">
                 <form method="POST" class="needs-validation" novalidate>
+    {{ csrf_token() }}
                     <div class="mb-3">
                         <label for="username" class="form-label">Username</label>
                         <input type="text" class="form-control" id="username" name="username" 

--- a/templates/admin/user_import.html
+++ b/templates/admin/user_import.html
@@ -21,6 +21,7 @@
             </div>
             <div class="card-body">
                 <form method="POST" enctype="multipart/form-data">
+    {{ csrf_token() }}
                     <div class="mb-3">
                         <label for="file" class="form-label">Choose CSV File</label>
                         <input type="file" class="form-control" id="file" name="file" accept=".csv" required>

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -59,6 +59,7 @@
                                             <form action="{{ url_for('admin.delete_user', user_id=user.id) }}" 
                                                   method="POST" class="d-inline"
                                                   onsubmit="return confirm('Are you sure you want to delete this user?');">
+    {{ csrf_token() }}
                                                 <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete">
                                                     <i class="bi bi-trash"></i>
                                                 </button>
@@ -94,6 +95,7 @@
             </div>
             <div class="modal-body">
                 <form action="{{ url_for('admin.user_import') }}" method="POST" enctype="multipart/form-data">
+    {{ csrf_token() }}
                     <div class="mb-3">
                         <label for="file" class="form-label">CSV File</label>
                         <input type="file" class="form-control" id="file" name="file" accept=".csv" required>

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -24,6 +24,7 @@
                     {% endwith %}
 
                     <form method="POST" class="needs-validation" novalidate>
+    {{ csrf_token() }}
                         <div class="mb-3">
                             <label for="email" class="form-label">Email Address</label>
                             <input type="email" class="form-control" id="email" name="email" required>

--- a/templates/auth/profile.html
+++ b/templates/auth/profile.html
@@ -18,6 +18,7 @@
                     {% endif %}
                 {% endwith %}
                 <form method="POST" action="{{ url_for('auth.update_profile') }}">
+    {{ csrf_token() }}
                     <div class="mb-3">
                         <label for="username" class="form-label">Username</label>
                         <input type="text" class="form-control" id="username" name="username" value="{{ current_user.username }}" required>

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -24,6 +24,7 @@
                     {% endwith %}
 
                     <form method="POST" class="needs-validation" novalidate>
+    {{ csrf_token() }}
                         <div class="mb-3">
                             <label for="username" class="form-label">Username</label>
                             <input type="text" class="form-control" id="username" name="username" required>

--- a/templates/donations.html
+++ b/templates/donations.html
@@ -24,6 +24,7 @@
                     {% endwith %}
 
                     <form method="POST" action="{{ url_for('donations.process_donation') }}" class="needs-validation" novalidate>
+    {{ csrf_token() }}
                         <div class="mb-3">
                             <label for="email" class="form-label">Email Address</label>
                             <input type="email" class="form-control" id="email" name="email" required>

--- a/templates/notifications/preferences.html
+++ b/templates/notifications/preferences.html
@@ -12,6 +12,7 @@
                 </div>
                 <div class="card-body">
                     <form method="POST" class="needs-validation" novalidate>
+    {{ csrf_token() }}
                         <h5 class="mb-3">Notification Categories</h5>
                         <div class="row g-3 mb-4">
                             <div class="col-md-6">

--- a/templates/prayers.html
+++ b/templates/prayers.html
@@ -31,6 +31,7 @@
                     {% endwith %}
 
                     <form method="POST" class="needs-validation" novalidate>
+    {{ csrf_token() }}
                         <div class="mb-3">
                             <label for="name" class="form-label">Your Name</label>
                             <input type="text" class="form-control" id="name" name="name" required>

--- a/templates/sermons.html
+++ b/templates/sermons.html
@@ -12,6 +12,7 @@
             <div class="card mb-4">
                 <div class="card-body">
                     <form method="GET" action="{{ url_for('sermons.search_sermons') }}" class="row g-3">
+    {{ csrf_token() }}
                         <div class="col-md-3">
                             <label for="title" class="form-label">Title</label>
                             <input type="text" class="form-control" id="title" name="title" value="{{ request.args.get('title', '') }}">


### PR DESCRIPTION
## Summary
- load config via environment with fallback secret key
- enable CSRF protection and inject tokens into forms
- switch donations to Decimal and queue async prayer email tasks

## Testing
- `python -m py_compile app.py routes/donations.py routes/prayers.py tasks.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c805eda86c8333b6824a09aedc46ad