### PR TITLE
Add event detail page and surface featured content

### DIFF
--- a/routes/home.py
+++ b/routes/home.py
@@ -1,7 +1,43 @@
-from flask import Blueprint, render_template
+from datetime import datetime
+
+from flask import Blueprint, current_app, render_template
+from sqlalchemy.exc import SQLAlchemyError
+
+from models import Event, Sermon
 
 home_bp = Blueprint('home', __name__)
 
+
 @home_bp.route('/')
 def home():
-    return render_template('home.html')
+    """Render the homepage with featured sermons and upcoming events."""
+    latest_sermons = []
+    upcoming_events = []
+
+    try:
+        latest_sermons = (
+            Sermon.query.order_by(Sermon.date.desc()).limit(3).all()
+        )
+    except SQLAlchemyError as exc:
+        current_app.logger.error(
+            f"Database error while fetching latest sermons: {exc}"
+        )
+
+    try:
+        upcoming_events = (
+            Event.query
+            .filter(Event.start_date >= datetime.utcnow())
+            .order_by(Event.start_date)
+            .limit(3)
+            .all()
+        )
+    except SQLAlchemyError as exc:
+        current_app.logger.error(
+            f"Database error while fetching upcoming events: {exc}"
+        )
+
+    return render_template(
+        'home.html',
+        latest_sermons=latest_sermons,
+        upcoming_events=upcoming_events
+    )

--- a/templates/event_detail.html
+++ b/templates/event_detail.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+
+{% block title %}{{ event.title }} - Covenant Connect{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <nav aria-label="breadcrumb" class="mb-4">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item"><a href="{{ url_for('events.events') }}">Events</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">{{ event.title }}</li>
+                </ol>
+            </nav>
+
+            <div class="card mb-4 shadow-sm">
+                <div class="card-body">
+                    <h1 class="card-title h2 mb-3">{{ event.title }}</h1>
+                    <p class="text-muted mb-1">
+                        <i class="bi bi-calendar-event me-2"></i>
+                        {{ event.start_date.strftime('%B %d, %Y') }}
+                        {% if event.end_date and event.end_date.date() != event.start_date.date() %}
+                            &ndash; {{ event.end_date.strftime('%B %d, %Y') }}
+                        {% endif %}
+                    </p>
+                    <p class="text-muted mb-1">
+                        <i class="bi bi-clock me-2"></i>
+                        {{ event.start_date.strftime('%I:%M %p') }}
+                        {% if event.end_date %}
+                            &ndash; {{ event.end_date.strftime('%I:%M %p') }}
+                        {% endif %}
+                    </p>
+                    {% if event.location %}
+                    <p class="text-muted mb-3">
+                        <i class="bi bi-geo-alt me-2"></i>{{ event.location }}
+                    </p>
+                    {% endif %}
+                    <hr>
+                    <p class="lead mb-0">{{ event.description or 'Details will be announced soon.' }}</p>
+                </div>
+            </div>
+
+            <div class="d-flex flex-wrap gap-2 mb-5">
+                <a href="{{ url_for('events.events') }}" class="btn btn-secondary">
+                    <i class="bi bi-arrow-left"></i> Back to Events
+                </a>
+                <a
+                    href="https://www.google.com/calendar/render?action=TEMPLATE&text={{ event.title|urlencode }}&dates={{ event.start_date.strftime('%Y%m%dT%H%M%S') }}{% if event.end_date %}/{{ event.end_date.strftime('%Y%m%dT%H%M%S') }}{% endif %}&details={{ (event.description or '')|urlencode }}&location={{ (event.location or '')|urlencode }}"
+                    class="btn btn-primary"
+                    target="_blank"
+                    rel="noopener"
+                >
+                    <i class="bi bi-calendar-plus"></i> Add to Calendar
+                </a>
+            </div>
+
+            {% if upcoming_events %}
+            <div class="card shadow-sm">
+                <div class="card-header">
+                    <h2 class="h5 mb-0">More Upcoming Events</h2>
+                </div>
+                <ul class="list-group list-group-flush">
+                    {% for upcoming in upcoming_events %}
+                    <li class="list-group-item d-flex justify-content-between align-items-start">
+                        <div class="me-3">
+                            <h3 class="h6 mb-1">
+                                <a href="{{ url_for('events.event_detail', event_id=upcoming.id) }}" class="text-decoration-none">
+                                    {{ upcoming.title }}
+                                </a>
+                            </h3>
+                            <small class="text-muted d-block">
+                                <i class="bi bi-calendar-event me-1"></i>{{ upcoming.start_date.strftime('%B %d, %Y') }}
+                            </small>
+                            {% if upcoming.location %}
+                            <small class="text-muted d-block">
+                                <i class="bi bi-geo-alt me-1"></i>{{ upcoming.location }}
+                            </small>
+                            {% endif %}
+                        </div>
+                        <a href="{{ url_for('events.event_detail', event_id=upcoming.id) }}" class="btn btn-outline-primary btn-sm">
+                            View
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/events.html
+++ b/templates/events.html
@@ -18,7 +18,9 @@
                     <div class="card h-100">
                         <div class="card-body">
                             <h5 class="card-title">{{ event.title }}</h5>
-                            <p class="card-text">{{ event.description[:150] }}...</p>
+                            <p class="card-text">
+                                {{ event.description | default('No description available.', true) | truncate(150, True, '...') }}
+                            </p>
                             <p class="card-text">
                                 <small class="text-muted">
                                     <i class="bi bi-calendar me-2"></i>Date: 


### PR DESCRIPTION
## Summary
- hydrate the homepage with featured sermons and upcoming events sourced from the database
- provide an events detail route and template with related upcoming events and an add-to-calendar shortcut
- harden event listings to handle missing descriptions without rendering errors

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c9dd11c4bc8333b1dbcf29fb094f01