### PR TITLE
Add sermon detail view with media playback

### DIFF
--- a/routes/home.py
+++ b/routes/home.py
@@ -1,7 +1,43 @@
-from flask import Blueprint, render_template
+from datetime import datetime
+
+from flask import Blueprint, current_app, render_template
+from sqlalchemy.exc import SQLAlchemyError
+
+from models import Event, Sermon
 
 home_bp = Blueprint('home', __name__)
 
+
 @home_bp.route('/')
 def home():
-    return render_template('home.html')
+    """Render the homepage with featured sermons and upcoming events."""
+    latest_sermons = []
+    upcoming_events = []
+
+    try:
+        latest_sermons = (
+            Sermon.query.order_by(Sermon.date.desc()).limit(3).all()
+        )
+    except SQLAlchemyError as exc:
+        current_app.logger.error(
+            f"Database error while fetching latest sermons: {exc}"
+        )
+
+    try:
+        upcoming_events = (
+            Event.query
+            .filter(Event.start_date >= datetime.utcnow())
+            .order_by(Event.start_date)
+            .limit(3)
+            .all()
+        )
+    except SQLAlchemyError as exc:
+        current_app.logger.error(
+            f"Database error while fetching upcoming events: {exc}"
+        )
+
+    return render_template(
+        'home.html',
+        latest_sermons=latest_sermons,
+        upcoming_events=upcoming_events
+    )

--- a/routes/sermons.py
+++ b/routes/sermons.py
@@ -1,9 +1,79 @@
-from flask import Blueprint, render_template, request, current_app
-from models import Sermon
-from sqlalchemy import or_, and_
 from datetime import datetime
+from typing import Dict, Optional
+from urllib.parse import parse_qs, urlparse
+
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from models import Sermon
+from sqlalchemy.exc import SQLAlchemyError
+
 
 sermons_bp = Blueprint('sermons', __name__)
+
+
+def _build_media_context(sermon: Sermon) -> Dict[str, Optional[str]]:
+    """Return template-friendly context describing how to render sermon media."""
+    media_type = (sermon.media_type or '').lower()
+    media_url = (sermon.media_url or '').strip()
+
+    if not media_url:
+        return {"type": None, "embed_url": None, "source_url": None}
+
+    if media_type == 'video':
+        embed_url = _resolve_video_embed(media_url)
+
+        return {
+            "type": 'video',
+            "embed_url": embed_url,
+            "source_url": media_url,
+        }
+
+    if media_type == 'audio':
+        return {
+            "type": 'audio',
+            "embed_url": media_url,
+            "source_url": media_url,
+        }
+
+    return {
+        "type": 'link',
+        "embed_url": None,
+        "source_url": media_url,
+    }
+
+
+def _resolve_video_embed(media_url: str) -> str:
+    """Convert known video providers into embeddable URLs when possible."""
+    parsed = urlparse(media_url)
+    host = parsed.netloc.lower()
+
+    if 'youtube.com' in host:
+        if parsed.path.startswith('/embed/'):
+            return media_url
+        if parsed.path == '/watch':
+            video_id = parse_qs(parsed.query).get('v', [''])[0]
+            if video_id:
+                return f'https://www.youtube.com/embed/{video_id}'
+    if 'youtu.be' in host:
+        video_id = parsed.path.lstrip('/')
+        if video_id:
+            return f'https://www.youtube.com/embed/{video_id}'
+    if 'vimeo.com' in host:
+        if 'player.vimeo.com' in host:
+            return media_url
+        video_id = parsed.path.strip('/').split('/')[-1]
+        if video_id:
+            return f'https://player.vimeo.com/video/{video_id}'
+
+    return media_url
+
 
 @sermons_bp.route('/sermons')
 def sermons():
@@ -26,16 +96,20 @@ def sermons():
             query = query.filter(Sermon.preacher.ilike(f'%{preacher}%'))
         if start_date:
             try:
-                start_date = datetime.strptime(start_date, '%Y-%m-%d')
-                query = query.filter(Sermon.date >= start_date)
+                start_date_parsed = datetime.strptime(start_date, '%Y-%m-%d')
+                query = query.filter(Sermon.date >= start_date_parsed)
             except ValueError:
-                current_app.logger.warning(f"Invalid start_date format: {start_date}")
+                current_app.logger.warning(
+                    f"Invalid start_date format: {start_date}"
+                )
         if end_date:
             try:
-                end_date = datetime.strptime(end_date, '%Y-%m-%d')
-                query = query.filter(Sermon.date <= end_date)
+                end_date_parsed = datetime.strptime(end_date, '%Y-%m-%d')
+                query = query.filter(Sermon.date <= end_date_parsed)
             except ValueError:
-                current_app.logger.warning(f"Invalid end_date format: {end_date}")
+                current_app.logger.warning(
+                    f"Invalid end_date format: {end_date}"
+                )
         if media_type:
             query = query.filter(Sermon.media_type == media_type)
 
@@ -43,11 +117,52 @@ def sermons():
         sermons_list = query.order_by(Sermon.date.desc()).all()
         return render_template('sermons.html', sermons=sermons_list)
 
-    except Exception as e:
-        current_app.logger.error(f"Error in sermons route: {str(e)}")
+    except Exception as exc:
+        current_app.logger.error(f"Error in sermons route: {exc}")
         return render_template('sermons.html', sermons=[])
+
 
 @sermons_bp.route('/sermons/search')
 def search_sermons():
     """Advanced search endpoint for sermons."""
     return sermons()  # Reuse the main sermons route as it already handles search
+
+
+@sermons_bp.route('/sermons/<int:sermon_id>')
+def sermon_detail(sermon_id: int):
+    """Render the detail page for a specific sermon with related content."""
+    try:
+        sermon = Sermon.query.get(sermon_id)
+        if not sermon:
+            flash('Sermon not found.', 'warning')
+            return redirect(url_for('sermons.sermons'))
+
+        related_sermons = (
+            Sermon.query
+            .filter(Sermon.id != sermon_id)
+            .order_by(Sermon.date.desc())
+            .limit(3)
+            .all()
+        )
+
+        media_context = _build_media_context(sermon)
+
+        return render_template(
+            'sermon_detail.html',
+            sermon=sermon,
+            related_sermons=related_sermons,
+            media_context=media_context,
+        )
+
+    except SQLAlchemyError as exc:
+        current_app.logger.error(
+            f"Database error while fetching sermon {sermon_id}: {exc}"
+        )
+        flash('Unable to load the sermon right now. Please try again later.', 'danger')
+        return redirect(url_for('sermons.sermons'))
+    except Exception as exc:
+        current_app.logger.error(
+            f"Unexpected error in sermon_detail route: {exc}"
+        )
+        flash('An unexpected error occurred. Please try again later.', 'danger')
+        return redirect(url_for('sermons.sermons'))

--- a/templates/event_detail.html
+++ b/templates/event_detail.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+
+{% block title %}{{ event.title }} - Covenant Connect{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <nav aria-label="breadcrumb" class="mb-4">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item"><a href="{{ url_for('events.events') }}">Events</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">{{ event.title }}</li>
+                </ol>
+            </nav>
+
+            <div class="card mb-4 shadow-sm">
+                <div class="card-body">
+                    <h1 class="card-title h2 mb-3">{{ event.title }}</h1>
+                    <p class="text-muted mb-1">
+                        <i class="bi bi-calendar-event me-2"></i>
+                        {{ event.start_date.strftime('%B %d, %Y') }}
+                        {% if event.end_date and event.end_date.date() != event.start_date.date() %}
+                            &ndash; {{ event.end_date.strftime('%B %d, %Y') }}
+                        {% endif %}
+                    </p>
+                    <p class="text-muted mb-1">
+                        <i class="bi bi-clock me-2"></i>
+                        {{ event.start_date.strftime('%I:%M %p') }}
+                        {% if event.end_date %}
+                            &ndash; {{ event.end_date.strftime('%I:%M %p') }}
+                        {% endif %}
+                    </p>
+                    {% if event.location %}
+                    <p class="text-muted mb-3">
+                        <i class="bi bi-geo-alt me-2"></i>{{ event.location }}
+                    </p>
+                    {% endif %}
+                    <hr>
+                    <p class="lead mb-0">{{ event.description or 'Details will be announced soon.' }}</p>
+                </div>
+            </div>
+
+            <div class="d-flex flex-wrap gap-2 mb-5">
+                <a href="{{ url_for('events.events') }}" class="btn btn-secondary">
+                    <i class="bi bi-arrow-left"></i> Back to Events
+                </a>
+                <a
+                    href="https://www.google.com/calendar/render?action=TEMPLATE&text={{ event.title|urlencode }}&dates={{ event.start_date.strftime('%Y%m%dT%H%M%S') }}{% if event.end_date %}/{{ event.end_date.strftime('%Y%m%dT%H%M%S') }}{% endif %}&details={{ (event.description or '')|urlencode }}&location={{ (event.location or '')|urlencode }}"
+                    class="btn btn-primary"
+                    target="_blank"
+                    rel="noopener"
+                >
+                    <i class="bi bi-calendar-plus"></i> Add to Calendar
+                </a>
+            </div>
+
+            {% if upcoming_events %}
+            <div class="card shadow-sm">
+                <div class="card-header">
+                    <h2 class="h5 mb-0">More Upcoming Events</h2>
+                </div>
+                <ul class="list-group list-group-flush">
+                    {% for upcoming in upcoming_events %}
+                    <li class="list-group-item d-flex justify-content-between align-items-start">
+                        <div class="me-3">
+                            <h3 class="h6 mb-1">
+                                <a href="{{ url_for('events.event_detail', event_id=upcoming.id) }}" class="text-decoration-none">
+                                    {{ upcoming.title }}
+                                </a>
+                            </h3>
+                            <small class="text-muted d-block">
+                                <i class="bi bi-calendar-event me-1"></i>{{ upcoming.start_date.strftime('%B %d, %Y') }}
+                            </small>
+                            {% if upcoming.location %}
+                            <small class="text-muted d-block">
+                                <i class="bi bi-geo-alt me-1"></i>{{ upcoming.location }}
+                            </small>
+                            {% endif %}
+                        </div>
+                        <a href="{{ url_for('events.event_detail', event_id=upcoming.id) }}" class="btn btn-outline-primary btn-sm">
+                            View
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/events.html
+++ b/templates/events.html
@@ -18,7 +18,9 @@
                     <div class="card h-100">
                         <div class="card-body">
                             <h5 class="card-title">{{ event.title }}</h5>
-                            <p class="card-text">{{ event.description[:150] }}...</p>
+                            <p class="card-text">
+                                {{ event.description | default('No description available.', true) | truncate(150, True, '...') }}
+                            </p>
                             <p class="card-text">
                                 <small class="text-muted">
                                     <i class="bi bi-calendar me-2"></i>Date: 

--- a/templates/home.html
+++ b/templates/home.html
@@ -62,11 +62,11 @@
                             <h5 class="card-title">{{ sermon.title }}</h5>
                             <p class="card-text">
                                 <small class="text-muted">
-                                    By {{ sermon.preacher }} | 
+                                    By {{ sermon.preacher or 'Guest Speaker' }} |
                                     {{ sermon.date.strftime('%B %d, %Y') }}
                                 </small>
                             </p>
-                            <a href="{{ url_for('sermons.sermon_detail', sermon_id=sermon.id) }}" 
+                            <a href="{{ url_for('sermons.sermon_detail', sermon_id=sermon.id) }}"
                                class="btn btn-outline-primary btn-sm">
                                 Watch/Listen
                             </a>
@@ -91,8 +91,8 @@
                             <h5 class="card-title">{{ event.title }}</h5>
                             <p class="card-text">
                                 <small class="text-muted">
-                                    {{ event.start_date.strftime('%B %d, %Y') }} | 
-                                    {{ event.location }}
+                                    {{ event.start_date.strftime('%B %d, %Y') }} |
+                                    {{ event.location or 'Location TBA' }}
                                 </small>
                             </p>
                             <a href="{{ url_for('events.event_detail', event_id=event.id) }}" 

--- a/templates/sermon_detail.html
+++ b/templates/sermon_detail.html
@@ -1,0 +1,115 @@
+{% extends "base.html" %}
+
+{% block title %}{{ sermon.title }} - Sermon - Covenant Connect{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <nav aria-label="breadcrumb" class="mb-4">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item"><a href="{{ url_for('sermons.sermons') }}">Sermons</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">{{ sermon.title }}</li>
+                </ol>
+            </nav>
+
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <h1 class="h2 mb-3">{{ sermon.title }}</h1>
+                    <p class="text-muted mb-1">
+                        <i class="bi bi-person me-2"></i>{{ sermon.preacher or 'Guest Speaker' }}
+                    </p>
+                    <p class="text-muted mb-3">
+                        <i class="bi bi-calendar-event me-2"></i>{{ sermon.date.strftime('%B %d, %Y') }}
+                    </p>
+
+                    {% if media_context.type == 'video' %}
+                        <div class="ratio ratio-16x9 mb-4">
+                            <iframe
+                                src="{{ media_context.embed_url }}"
+                                title="{{ sermon.title }}"
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                allowfullscreen
+                            ></iframe>
+                        </div>
+                        <p class="small text-muted">
+                            Having trouble viewing?
+                            <a href="{{ media_context.source_url }}" target="_blank" rel="noopener">Open the video in a new tab</a>.
+                        </p>
+                    {% elif media_context.type == 'audio' %}
+                        <div class="mb-4">
+                            <audio controls class="w-100">
+                                <source src="{{ media_context.embed_url }}">
+                                Your browser does not support the audio element.
+                            </audio>
+                            <p class="small text-muted mt-2">
+                                Prefer downloading?
+                                <a href="{{ media_context.source_url }}" target="_blank" rel="noopener">Click here to access the audio file</a>.
+                            </p>
+                        </div>
+                    {% elif media_context.source_url %}
+                        <div class="alert alert-info d-flex align-items-center" role="alert">
+                            <i class="bi bi-link-45deg fs-3 me-2"></i>
+                            <div>
+                                This sermon has an external resource.
+                                <a href="{{ media_context.source_url }}" class="alert-link" target="_blank" rel="noopener">Open the media</a> to watch or listen.
+                            </div>
+                        </div>
+                    {% endif %}
+
+                    <hr>
+                    <p class="lead">{{ sermon.description or 'Details for this sermon will be available soon.' }}</p>
+                </div>
+            </div>
+
+            <div class="d-flex flex-wrap gap-2 mb-5">
+                <a href="{{ url_for('sermons.sermons') }}" class="btn btn-secondary">
+                    <i class="bi bi-arrow-left"></i> Back to Sermons
+                </a>
+                {% if media_context.source_url %}
+                <a
+                    href="{{ media_context.source_url }}"
+                    class="btn btn-primary"
+                    target="_blank"
+                    rel="noopener"
+                >
+                    <i class="bi bi-play-circle"></i> Open Media
+                </a>
+                {% endif %}
+            </div>
+
+            {% if related_sermons %}
+            <div class="card shadow-sm">
+                <div class="card-header">
+                    <h2 class="h5 mb-0">Other Recent Sermons</h2>
+                </div>
+                <ul class="list-group list-group-flush">
+                    {% for related in related_sermons %}
+                    <li class="list-group-item d-flex justify-content-between align-items-start">
+                        <div class="me-3">
+                            <h3 class="h6 mb-1">
+                                <a href="{{ url_for('sermons.sermon_detail', sermon_id=related.id) }}" class="text-decoration-none">
+                                    {{ related.title }}
+                                </a>
+                            </h3>
+                            <small class="text-muted d-block">
+                                <i class="bi bi-calendar-event me-1"></i>{{ related.date.strftime('%B %d, %Y') }}
+                            </small>
+                            {% if related.preacher %}
+                            <small class="text-muted d-block">
+                                <i class="bi bi-person me-1"></i>{{ related.preacher }}
+                            </small>
+                            {% endif %}
+                        </div>
+                        <a href="{{ url_for('sermons.sermon_detail', sermon_id=related.id) }}" class="btn btn-outline-primary btn-sm">
+                            View
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/sermons.html
+++ b/templates/sermons.html
@@ -51,22 +51,31 @@
                     {% for sermon in sermons %}
                         <div class="col">
                             <div class="card h-100">
-                                <div class="card-body">
+                                <div class="card-body d-flex flex-column">
                                     <h5 class="card-title">{{ sermon.title }}</h5>
                                     <p class="card-text">
                                         <small class="text-muted">
-                                            <i class="bi bi-person"></i> {{ sermon.preacher }}<br>
+                                            <i class="bi bi-person"></i> {{ sermon.preacher or 'Guest Speaker' }}<br>
                                             <i class="bi bi-calendar"></i> {{ sermon.date.strftime('%B %d, %Y') }}
                                         </small>
                                     </p>
-                                    <p class="card-text">{{ sermon.description }}</p>
-                                    <div class="d-flex justify-content-between align-items-center">
-                                        <span class="badge bg-{{ 'primary' if sermon.media_type == 'video' else 'info' }}">
-                                            {{ sermon.media_type.title() }}
+                                    <p class="card-text flex-grow-1">
+                                        {{ sermon.description | default('Details for this sermon are coming soon.', true) | truncate(160, True, '...') }}
+                                    </p>
+                                    <div class="d-flex justify-content-between align-items-center mt-3">
+                                        <span class="badge bg-{{ 'primary' if sermon.media_type == 'video' else ('info' if sermon.media_type == 'audio' else 'secondary') }}">
+                                            {{ (sermon.media_type or 'Media')|title }}
                                         </span>
-                                        <a href="{{ sermon.media_url }}" class="btn btn-sm btn-outline-primary" target="_blank">
-                                            <i class="bi bi-play-circle"></i> Watch/Listen
-                                        </a>
+                                        <div class="btn-group">
+                                            <a href="{{ url_for('sermons.sermon_detail', sermon_id=sermon.id) }}" class="btn btn-sm btn-outline-primary">
+                                                <i class="bi bi-journal-text"></i> Details
+                                            </a>
+                                            {% if sermon.media_url %}
+                                            <a href="{{ sermon.media_url }}" class="btn btn-sm btn-primary" target="_blank" rel="noopener">
+                                                <i class="bi bi-play-circle"></i>
+                                            </a>
+                                            {% endif %}
+                                        </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- add a sermon detail route that surfaces related sermons and handles database errors gracefully
- render a new sermon detail template with media playback for YouTube, Vimeo, and audio sources plus external fallbacks
- polish sermon listings and homepage cards to tolerate missing speakers and locations while linking to the new detail view

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c9dd11c4bc8333b1dbcf29fb094f01