### PR TITLE
Add ministry departments and volunteer coordination

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,9 +1,21 @@
 from flask import Blueprint, render_template, current_app, flash, redirect, url_for, request
 from flask_login import login_required, current_user
-from models import PrayerRequest, Event, Sermon, Donation, User, Gallery, Settings
+from models import (
+    PrayerRequest,
+    Event,
+    Sermon,
+    Donation,
+    User,
+    Gallery,
+    Settings,
+    MinistryDepartment,
+    VolunteerRole,
+    VolunteerAssignment,
+)
 from app import db
 from sqlalchemy import func
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import joinedload
 from datetime import datetime, time
 from decimal import Decimal
 from functools import wraps
@@ -220,8 +232,16 @@ def user_import():
 @admin_required
 def events():
     try:
-        events = Event.query.order_by(Event.start_date.desc()).all()
-        return render_template('admin/events.html', events=events)
+        events = (
+            Event.query.options(
+                joinedload(Event.department),
+                joinedload(Event.volunteer_role).joinedload(VolunteerRole.department),
+                joinedload(Event.volunteer_role).joinedload(VolunteerRole.coordinator),
+            )
+            .order_by(Event.start_date.desc())
+            .all()
+        )
+        return render_template('admin/events.html', events=events, now=datetime.now())
     except SQLAlchemyError as e:
         current_app.logger.error(f"Database error in events route: {str(e)}")
         db.session.rollback()
@@ -237,6 +257,12 @@ def events():
 @admin_required
 def create_event():
     try:
+        departments = MinistryDepartment.query.order_by(MinistryDepartment.name).all()
+        roles = (
+            VolunteerRole.query.options(joinedload(VolunteerRole.department))
+            .order_by(VolunteerRole.name)
+            .all()
+        )
         if request.method == 'POST':
             event = Event()
             event.title = request.form['title']
@@ -244,11 +270,47 @@ def create_event():
             event.start_date = datetime.strptime(f"{request.form['start_date']} {request.form['start_time']}", '%Y-%m-%d %H:%M')
             event.end_date = datetime.strptime(f"{request.form['end_date']} {request.form['end_time']}", '%Y-%m-%d %H:%M')
             event.location = request.form['location']
+            department_id = request.form.get('department_id')
+            role_id = request.form.get('volunteer_role_id')
+            event.department_id = int(department_id) if department_id else None
+            event.volunteer_role_id = int(role_id) if role_id else None
+
+            if event.department_id and not db.session.get(MinistryDepartment, event.department_id):
+                flash('Selected department could not be found.', 'danger')
+                return render_template(
+                    'admin/event_form.html',
+                    event=event,
+                    departments=departments,
+                    roles=roles,
+                )
+
+            if event.volunteer_role_id:
+                role = db.session.get(VolunteerRole, event.volunteer_role_id)
+                if not role:
+                    flash('Selected serving role could not be found.', 'danger')
+                    return render_template(
+                        'admin/event_form.html',
+                        event=event,
+                        departments=departments,
+                        roles=roles,
+                    )
+                if event.department_id and role.department_id != event.department_id:
+                    flash('Selected role does not belong to the chosen department.', 'danger')
+                    return render_template(
+                        'admin/event_form.html',
+                        event=event,
+                        departments=departments,
+                        roles=roles,
+                    )
             db.session.add(event)
             db.session.commit()
             flash('Event created successfully.', 'success')
             return redirect(url_for('admin.events'))
-        return render_template('admin/event_form.html')
+        return render_template(
+            'admin/event_form.html',
+            departments=departments,
+            roles=roles,
+        )
     except SQLAlchemyError as e:
         current_app.logger.error(f"Database error creating event: {str(e)}")
         db.session.rollback()
@@ -265,16 +327,59 @@ def create_event():
 def edit_event(event_id):
     try:
         event = Event.query.get_or_404(event_id)
+        departments = MinistryDepartment.query.order_by(MinistryDepartment.name).all()
+        roles = (
+            VolunteerRole.query.options(joinedload(VolunteerRole.department))
+            .order_by(VolunteerRole.name)
+            .all()
+        )
         if request.method == 'POST':
             event.title = request.form['title']
             event.description = request.form['description']
             event.start_date = datetime.strptime(f"{request.form['start_date']} {request.form['start_time']}", '%Y-%m-%d %H:%M')
             event.end_date = datetime.strptime(f"{request.form['end_date']} {request.form['end_time']}", '%Y-%m-%d %H:%M')
             event.location = request.form['location']
+            department_id = request.form.get('department_id')
+            role_id = request.form.get('volunteer_role_id')
+            event.department_id = int(department_id) if department_id else None
+            event.volunteer_role_id = int(role_id) if role_id else None
+
+            if event.department_id and not db.session.get(MinistryDepartment, event.department_id):
+                flash('Selected department could not be found.', 'danger')
+                return render_template(
+                    'admin/event_form.html',
+                    event=event,
+                    departments=departments,
+                    roles=roles,
+                )
+
+            if event.volunteer_role_id:
+                role = db.session.get(VolunteerRole, event.volunteer_role_id)
+                if not role:
+                    flash('Selected serving role could not be found.', 'danger')
+                    return render_template(
+                        'admin/event_form.html',
+                        event=event,
+                        departments=departments,
+                        roles=roles,
+                    )
+                if event.department_id and role.department_id != event.department_id:
+                    flash('Selected role does not belong to the chosen department.', 'danger')
+                    return render_template(
+                        'admin/event_form.html',
+                        event=event,
+                        departments=departments,
+                        roles=roles,
+                    )
             db.session.commit()
             flash('Event updated successfully.', 'success')
             return redirect(url_for('admin.events'))
-        return render_template('admin/event_form.html', event=event)
+        return render_template(
+            'admin/event_form.html',
+            event=event,
+            departments=departments,
+            roles=roles,
+        )
     except SQLAlchemyError as e:
         current_app.logger.error(f"Database error editing event: {str(e)}")
         db.session.rollback()
@@ -302,6 +407,439 @@ def delete_event(event_id):
         current_app.logger.error(f"Error deleting event: {str(e)}")
         flash('An error occurred while deleting event.', 'danger')
     return redirect(url_for('admin.events'))
+
+# Department Management Routes
+@admin_bp.route('/admin/departments')
+@login_required
+@admin_required
+def departments():
+    try:
+        departments = (
+            MinistryDepartment.query.options(
+                joinedload(MinistryDepartment.lead),
+                joinedload(MinistryDepartment.roles).joinedload(VolunteerRole.coordinator),
+            )
+            .order_by(MinistryDepartment.name)
+            .all()
+        )
+        return render_template('admin/departments/index.html', departments=departments)
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error loading departments: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while loading departments.', 'danger')
+        return redirect(url_for('admin.dashboard'))
+    except Exception as e:
+        current_app.logger.error(f"Unexpected error loading departments: {str(e)}")
+        flash('An error occurred while loading departments.', 'danger')
+        return redirect(url_for('admin.dashboard'))
+
+
+@admin_bp.route('/admin/departments/create', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def create_department():
+    try:
+        users = User.query.order_by(User.username).all()
+        if request.method == 'POST':
+            department = MinistryDepartment()
+            department.name = request.form['name']
+            department.description = request.form.get('description')
+            lead_id = request.form.get('lead_id')
+            department.lead_id = int(lead_id) if lead_id else None
+            db.session.add(department)
+            db.session.commit()
+            flash('Department created successfully.', 'success')
+            return redirect(url_for('admin.departments'))
+        return render_template('admin/departments/form.html', users=users)
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error creating department: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while creating department.', 'danger')
+        return redirect(url_for('admin.departments'))
+    except Exception as e:
+        current_app.logger.error(f"Error creating department: {str(e)}")
+        flash('An error occurred while creating department.', 'danger')
+        return redirect(url_for('admin.departments'))
+
+
+@admin_bp.route('/admin/departments/<int:department_id>/edit', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def edit_department(department_id):
+    try:
+        department = MinistryDepartment.query.get_or_404(department_id)
+        users = User.query.order_by(User.username).all()
+        if request.method == 'POST':
+            department.name = request.form['name']
+            department.description = request.form.get('description')
+            lead_id = request.form.get('lead_id')
+            department.lead_id = int(lead_id) if lead_id else None
+            db.session.commit()
+            flash('Department updated successfully.', 'success')
+            return redirect(url_for('admin.departments'))
+        return render_template(
+            'admin/departments/form.html', department=department, users=users
+        )
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error editing department: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while editing department.', 'danger')
+        return redirect(url_for('admin.departments'))
+    except Exception as e:
+        current_app.logger.error(f"Error editing department: {str(e)}")
+        flash('An error occurred while editing department.', 'danger')
+        return redirect(url_for('admin.departments'))
+
+
+@admin_bp.route('/admin/departments/<int:department_id>')
+@login_required
+@admin_required
+def department_detail(department_id):
+    try:
+        department = (
+            MinistryDepartment.query.options(
+                joinedload(MinistryDepartment.lead),
+                joinedload(MinistryDepartment.roles)
+                .joinedload(VolunteerRole.coordinator),
+                joinedload(MinistryDepartment.roles)
+                .joinedload(VolunteerRole.assignments)
+                .joinedload(VolunteerAssignment.volunteer),
+                joinedload(MinistryDepartment.events),
+            )
+            .get_or_404(department_id)
+        )
+        upcoming_events = [
+            event for event in department.events if event.start_date >= datetime.now()
+        ]
+        upcoming_events.sort(key=lambda event: event.start_date)
+        return render_template(
+            'admin/departments/detail.html',
+            department=department,
+            upcoming_events=upcoming_events,
+        )
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error loading department: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while loading the department.', 'danger')
+        return redirect(url_for('admin.departments'))
+    except Exception as e:
+        current_app.logger.error(f"Error loading department: {str(e)}")
+        flash('An error occurred while loading the department.', 'danger')
+        return redirect(url_for('admin.departments'))
+
+
+@admin_bp.route('/admin/departments/<int:department_id>/delete', methods=['POST'])
+@login_required
+@admin_required
+def delete_department(department_id):
+    try:
+        department = MinistryDepartment.query.get_or_404(department_id)
+        for event in list(department.events):
+            event.department_id = None
+            if event.volunteer_role and event.volunteer_role.department_id == department.id:
+                event.volunteer_role_id = None
+        for role in list(department.roles):
+            for event in list(role.events):
+                event.volunteer_role_id = None
+        db.session.delete(department)
+        db.session.commit()
+        flash('Department deleted successfully.', 'success')
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error deleting department: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while deleting department.', 'danger')
+    except Exception as e:
+        current_app.logger.error(f"Error deleting department: {str(e)}")
+        flash('An error occurred while deleting department.', 'danger')
+    return redirect(url_for('admin.departments'))
+
+
+@admin_bp.route('/admin/departments/<int:department_id>/roles/create', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def create_role(department_id):
+    try:
+        department = MinistryDepartment.query.get_or_404(department_id)
+        users = User.query.order_by(User.username).all()
+        if request.method == 'POST':
+            role = VolunteerRole()
+            role.department = department
+            role.name = request.form['name']
+            role.description = request.form.get('description')
+            coordinator_id = request.form.get('coordinator_id')
+            role.coordinator_id = int(coordinator_id) if coordinator_id else None
+            db.session.add(role)
+            db.session.commit()
+            flash('Volunteer role created successfully.', 'success')
+            return redirect(url_for('admin.department_detail', department_id=department.id))
+        return render_template(
+            'admin/departments/role_form.html',
+            department=department,
+            users=users,
+        )
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error creating role: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while creating volunteer role.', 'danger')
+        return redirect(url_for('admin.department_detail', department_id=department_id))
+    except Exception as e:
+        current_app.logger.error(f"Error creating role: {str(e)}")
+        flash('An error occurred while creating volunteer role.', 'danger')
+        return redirect(url_for('admin.department_detail', department_id=department_id))
+
+
+@admin_bp.route('/admin/departments/<int:department_id>/roles/<int:role_id>/edit', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def edit_role(department_id, role_id):
+    try:
+        department = MinistryDepartment.query.get_or_404(department_id)
+        role = VolunteerRole.query.get_or_404(role_id)
+        if role.department_id != department.id:
+            flash('Volunteer role does not belong to this department.', 'danger')
+            return redirect(url_for('admin.department_detail', department_id=department.id))
+        users = User.query.order_by(User.username).all()
+        if request.method == 'POST':
+            role.name = request.form['name']
+            role.description = request.form.get('description')
+            coordinator_id = request.form.get('coordinator_id')
+            role.coordinator_id = int(coordinator_id) if coordinator_id else None
+            db.session.commit()
+            flash('Volunteer role updated successfully.', 'success')
+            return redirect(url_for('admin.department_detail', department_id=department.id))
+        return render_template(
+            'admin/departments/role_form.html',
+            department=department,
+            role=role,
+            users=users,
+        )
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error updating role: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while updating volunteer role.', 'danger')
+        return redirect(url_for('admin.department_detail', department_id=department_id))
+    except Exception as e:
+        current_app.logger.error(f"Error updating role: {str(e)}")
+        flash('An error occurred while updating volunteer role.', 'danger')
+        return redirect(url_for('admin.department_detail', department_id=department_id))
+
+
+@admin_bp.route('/admin/departments/<int:department_id>/roles/<int:role_id>/delete', methods=['POST'])
+@login_required
+@admin_required
+def delete_role(department_id, role_id):
+    try:
+        role = VolunteerRole.query.get_or_404(role_id)
+        if role.department_id != department_id:
+            flash('Volunteer role does not belong to the specified department.', 'danger')
+            return redirect(url_for('admin.department_detail', department_id=department_id))
+        for event in list(role.events):
+            event.volunteer_role_id = None
+        db.session.delete(role)
+        db.session.commit()
+        flash('Volunteer role deleted successfully.', 'success')
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error deleting role: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while deleting volunteer role.', 'danger')
+    except Exception as e:
+        current_app.logger.error(f"Error deleting role: {str(e)}")
+        flash('An error occurred while deleting volunteer role.', 'danger')
+    return redirect(url_for('admin.department_detail', department_id=department_id))
+
+
+# Volunteer Assignment Routes
+@admin_bp.route('/admin/volunteers')
+@login_required
+@admin_required
+def volunteers():
+    try:
+        assignments = (
+            VolunteerAssignment.query.options(
+                joinedload(VolunteerAssignment.volunteer),
+                joinedload(VolunteerAssignment.role)
+                .joinedload(VolunteerRole.department),
+                joinedload(VolunteerAssignment.role)
+                .joinedload(VolunteerRole.coordinator),
+            )
+            .order_by(VolunteerAssignment.created_at.desc())
+            .all()
+        )
+        return render_template('admin/volunteers/index.html', assignments=assignments)
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error loading volunteers: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while loading volunteer assignments.', 'danger')
+        return redirect(url_for('admin.dashboard'))
+    except Exception as e:
+        current_app.logger.error(f"Error loading volunteers: {str(e)}")
+        flash('An error occurred while loading volunteer assignments.', 'danger')
+        return redirect(url_for('admin.dashboard'))
+
+
+@admin_bp.route('/admin/volunteers/create', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def create_volunteer_assignment():
+    try:
+        volunteers = User.query.order_by(User.username).all()
+        roles = (
+            VolunteerRole.query.options(joinedload(VolunteerRole.department))
+            .order_by(VolunteerRole.name)
+            .all()
+        )
+        if request.method == 'POST':
+            role_id = request.form.get('role_id')
+            volunteer_id = request.form.get('volunteer_id')
+            if not role_id or not volunteer_id:
+                flash('Please select both a serving role and a volunteer.', 'danger')
+                return render_template(
+                    'admin/volunteers/form.html',
+                    roles=roles,
+                    volunteers=volunteers,
+                )
+            role = db.session.get(VolunteerRole, int(role_id))
+            volunteer = db.session.get(User, int(volunteer_id))
+            if not role or not volunteer:
+                flash('Invalid role or volunteer selection.', 'danger')
+                return render_template(
+                    'admin/volunteers/form.html',
+                    roles=roles,
+                    volunteers=volunteers,
+                )
+            existing = VolunteerAssignment.query.filter_by(
+                role_id=role.id, volunteer_id=volunteer.id
+            ).first()
+            if existing:
+                flash('This volunteer is already assigned to the selected role.', 'warning')
+                return redirect(
+                    url_for('admin.edit_volunteer_assignment', assignment_id=existing.id)
+                )
+
+            assignment = VolunteerAssignment()
+            assignment.role = role
+            assignment.volunteer = volunteer
+            start_date = request.form.get('start_date')
+            end_date = request.form.get('end_date')
+            if start_date:
+                assignment.start_date = datetime.strptime(start_date, '%Y-%m-%d').date()
+            if end_date:
+                assignment.end_date = datetime.strptime(end_date, '%Y-%m-%d').date()
+            assignment.notes = request.form.get('notes')
+            db.session.add(assignment)
+            db.session.commit()
+            flash('Volunteer assignment created successfully.', 'success')
+            return redirect(url_for('admin.volunteers'))
+        return render_template(
+            'admin/volunteers/form.html',
+            roles=roles,
+            volunteers=volunteers,
+        )
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error creating assignment: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while creating volunteer assignment.', 'danger')
+        return redirect(url_for('admin.volunteers'))
+    except Exception as e:
+        current_app.logger.error(f"Error creating assignment: {str(e)}")
+        flash('An error occurred while creating volunteer assignment.', 'danger')
+        return redirect(url_for('admin.volunteers'))
+
+
+@admin_bp.route('/admin/volunteers/<int:assignment_id>/edit', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def edit_volunteer_assignment(assignment_id):
+    try:
+        assignment = VolunteerAssignment.query.get_or_404(assignment_id)
+        volunteers = User.query.order_by(User.username).all()
+        roles = (
+            VolunteerRole.query.options(joinedload(VolunteerRole.department))
+            .order_by(VolunteerRole.name)
+            .all()
+        )
+        if request.method == 'POST':
+            role_id = request.form.get('role_id')
+            volunteer_id = request.form.get('volunteer_id')
+            if not role_id or not volunteer_id:
+                flash('Please select both a serving role and a volunteer.', 'danger')
+                return render_template(
+                    'admin/volunteers/form.html',
+                    assignment=assignment,
+                    roles=roles,
+                    volunteers=volunteers,
+                )
+            role = db.session.get(VolunteerRole, int(role_id))
+            volunteer = db.session.get(User, int(volunteer_id))
+            if not role or not volunteer:
+                flash('Invalid role or volunteer selection.', 'danger')
+                return render_template(
+                    'admin/volunteers/form.html',
+                    assignment=assignment,
+                    roles=roles,
+                    volunteers=volunteers,
+                )
+            duplicate = (
+                VolunteerAssignment.query.filter(
+                    VolunteerAssignment.id != assignment.id,
+                    VolunteerAssignment.role_id == role.id,
+                    VolunteerAssignment.volunteer_id == volunteer.id,
+                )
+                .first()
+            )
+            if duplicate:
+                flash('Another assignment already uses this role and volunteer.', 'warning')
+                return redirect(
+                    url_for('admin.edit_volunteer_assignment', assignment_id=duplicate.id)
+                )
+            assignment.role = role
+            assignment.volunteer = volunteer
+            start_date = request.form.get('start_date')
+            end_date = request.form.get('end_date')
+            assignment.start_date = (
+                datetime.strptime(start_date, '%Y-%m-%d').date() if start_date else None
+            )
+            assignment.end_date = (
+                datetime.strptime(end_date, '%Y-%m-%d').date() if end_date else None
+            )
+            assignment.notes = request.form.get('notes')
+            db.session.commit()
+            flash('Volunteer assignment updated successfully.', 'success')
+            return redirect(url_for('admin.volunteers'))
+        return render_template(
+            'admin/volunteers/form.html',
+            assignment=assignment,
+            roles=roles,
+            volunteers=volunteers,
+        )
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error updating assignment: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while updating volunteer assignment.', 'danger')
+        return redirect(url_for('admin.volunteers'))
+    except Exception as e:
+        current_app.logger.error(f"Error updating assignment: {str(e)}")
+        flash('An error occurred while updating volunteer assignment.', 'danger')
+        return redirect(url_for('admin.volunteers'))
+
+
+@admin_bp.route('/admin/volunteers/<int:assignment_id>/delete', methods=['POST'])
+@login_required
+@admin_required
+def delete_volunteer_assignment(assignment_id):
+    try:
+        assignment = VolunteerAssignment.query.get_or_404(assignment_id)
+        db.session.delete(assignment)
+        db.session.commit()
+        flash('Volunteer assignment deleted successfully.', 'success')
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Database error deleting assignment: {str(e)}")
+        db.session.rollback()
+        flash('An error occurred while deleting volunteer assignment.', 'danger')
+    except Exception as e:
+        current_app.logger.error(f"Error deleting assignment: {str(e)}")
+        flash('An error occurred while deleting volunteer assignment.', 'danger')
+    return redirect(url_for('admin.volunteers'))
 
 # Prayer Request Management Routes
 @admin_bp.route('/admin/prayers')

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -4,25 +4,40 @@
 <div class="container-fluid">
     <div class="row">
         <!-- Admin Sidebar -->
+        {% set endpoint = request.endpoint or '' %}
         <nav class="col-md-2 d-md-block sidebar collapse">
             <div class="sidebar-sticky">
                 <ul class="nav flex-column">
                     <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.dashboard' %}active{% endif %}" 
+                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.dashboard' %}active{% endif %}"
                            href="{{ url_for('admin.dashboard') }}">
                             <i class="bi bi-speedometer2"></i>
                             <span>Dashboard</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.users' %}active{% endif %}" 
+                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.users' %}active{% endif %}"
                            href="{{ url_for('admin.users') }}">
                             <i class="bi bi-people"></i>
                             <span>Users</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.events' %}active{% endif %}" 
+                        <a class="nav-link d-flex align-items-center {% if 'department' in endpoint %}active{% endif %}"
+                           href="{{ url_for('admin.departments') }}">
+                            <i class="bi bi-diagram-3"></i>
+                            <span>Departments</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link d-flex align-items-center {% if 'volunteer' in endpoint %}active{% endif %}"
+                           href="{{ url_for('admin.volunteers') }}">
+                            <i class="bi bi-person-heart"></i>
+                            <span>Volunteers</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.events' %}active{% endif %}"
                            href="{{ url_for('admin.events') }}">
                             <i class="bi bi-calendar-event"></i>
                             <span>Events</span>

--- a/templates/admin/departments/detail.html
+++ b/templates/admin/departments/detail.html
@@ -1,0 +1,163 @@
+{% extends "admin/base.html" %}
+
+{% block admin_content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1>{{ department.name }}</h1>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <a href="{{ url_for('admin.edit_department', department_id=department.id) }}" class="btn btn-sm btn-outline-primary me-2">
+            <i class="bi bi-pencil"></i> Edit
+        </a>
+        <a href="{{ url_for('admin.create_role', department_id=department.id) }}" class="btn btn-sm btn-primary">
+            <i class="bi bi-person-plus"></i> New Role
+        </a>
+    </div>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+{% endwith %}
+
+<div class="row gy-4">
+    <div class="col-lg-7">
+        <div class="card h-100">
+            <div class="card-body">
+                <h2 class="h5 mb-3">Department Overview</h2>
+                {% if department.description %}
+                    <p class="mb-3">{{ department.description }}</p>
+                {% else %}
+                    <p class="text-muted">No description has been added for this department yet.</p>
+                {% endif %}
+                <dl class="row mb-0">
+                    <dt class="col-sm-4">Staff Lead</dt>
+                    <dd class="col-sm-8">
+                        {% if department.lead %}
+                            {{ department.lead.username }} &lt;{{ department.lead.email }}&gt;
+                        {% else %}
+                            <span class="text-muted">Unassigned</span>
+                        {% endif %}
+                    </dd>
+                    <dt class="col-sm-4">Total Roles</dt>
+                    <dd class="col-sm-8">{{ department.roles|length }}</dd>
+                </dl>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-5">
+        <div class="card h-100">
+            <div class="card-body">
+                <h2 class="h5 mb-3">Upcoming Events</h2>
+                {% if upcoming_events %}
+                    <ul class="list-group list-group-flush">
+                        {% for event in upcoming_events %}
+                            <li class="list-group-item">
+                                <div class="fw-semibold">{{ event.title }}</div>
+                                <small class="text-muted d-block">
+                                    <i class="bi bi-calendar-event me-1"></i>{{ event.start_date.strftime('%b %d, %Y %I:%M %p') }}
+                                </small>
+                                {% if event.volunteer_role %}
+                                    <small class="text-muted d-block">
+                                        <i class="bi bi-person-check me-1"></i>{{ event.volunteer_role.name }}
+                                    </small>
+                                {% endif %}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <p class="text-muted mb-0">No upcoming events assigned to this department.</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card mt-4">
+    <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h2 class="h5 mb-0">Volunteer Roles</h2>
+            <a href="{{ url_for('admin.create_role', department_id=department.id) }}" class="btn btn-sm btn-outline-primary">
+                <i class="bi bi-person-plus"></i> Add Role
+            </a>
+        </div>
+        {% if department.roles %}
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col">Role</th>
+                            <th scope="col">Coordinator</th>
+                            <th scope="col">Volunteers</th>
+                            <th scope="col">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for role in department.roles %}
+                            <tr>
+                                <td>
+                                    <div class="fw-semibold">{{ role.name }}</div>
+                                    {% if role.description %}
+                                        <div class="text-muted small">{{ role.description }}</div>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if role.coordinator %}
+                                        {{ role.coordinator.username }}
+                                    {% else %}
+                                        <span class="text-muted">Unassigned</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if role.assignments %}
+                                        <div class="d-flex flex-column gap-1">
+                                            {% for assignment in role.assignments %}
+                                                <span class="badge bg-light text-dark">
+                                                    {{ assignment.volunteer.username }}
+                                                    {% if assignment.start_date %}
+                                                        <small class="text-muted ms-2">since {{ assignment.start_date.strftime('%b %Y') }}</small>
+                                                    {% endif %}
+                                                </span>
+                                            {% endfor %}
+                                        </div>
+                                    {% else %}
+                                        <span class="text-muted">No volunteers assigned</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <div class="btn-group" role="group">
+                                        <a href="{{ url_for('admin.edit_role', department_id=department.id, role_id=role.id) }}"
+                                           class="btn btn-sm btn-outline-primary" title="Edit Role">
+                                            <i class="bi bi-pencil"></i>
+                                        </a>
+                                        <form action="{{ url_for('admin.delete_role', department_id=department.id, role_id=role.id) }}"
+                                              method="POST" class="d-inline"
+                                              onsubmit="return confirm('Delete this volunteer role?');">
+                                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete Role">
+                                                <i class="bi bi-trash"></i>
+                                            </button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <div class="text-center py-4">
+                <i class="bi bi-people display-5 text-muted mb-3"></i>
+                <p class="text-muted">No volunteer roles have been set up for this department yet.</p>
+                <a href="{{ url_for('admin.create_role', department_id=department.id) }}" class="btn btn-primary btn-sm">
+                    <i class="bi bi-person-plus"></i> Create a Role
+                </a>
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/departments/form.html
+++ b/templates/admin/departments/form.html
@@ -1,0 +1,73 @@
+{% extends "admin/base.html" %}
+
+{% block admin_content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1>{{ department and 'Edit Department' or 'Create Department' }}</h1>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+{% endwith %}
+
+<div class="card">
+    <div class="card-body">
+        <form method="POST" class="needs-validation" novalidate>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="mb-3">
+                <label for="name" class="form-label">Department Name</label>
+                <input type="text" class="form-control" id="name" name="name"
+                       value="{{ department.name if department }}" required>
+                <div class="invalid-feedback">
+                    Please provide a department name.
+                </div>
+            </div>
+            <div class="mb-3">
+                <label for="description" class="form-label">Description</label>
+                <textarea class="form-control" id="description" name="description" rows="4"
+                          placeholder="Describe the purpose of this team">{{ department.description if department }}</textarea>
+            </div>
+            <div class="mb-4">
+                <label for="lead_id" class="form-label">Staff Lead</label>
+                <select class="form-select" id="lead_id" name="lead_id">
+                    <option value="">-- No lead assigned --</option>
+                    {% for user in users %}
+                        <option value="{{ user.id }}" {% if department and department.lead_id == user.id %}selected{% endif %}>
+                            {{ user.username }} ({{ user.email }})
+                        </option>
+                    {% endfor %}
+                </select>
+                <div class="form-text">Assign a staff member to oversee this ministry department.</div>
+            </div>
+            <div class="d-grid gap-2 d-sm-flex justify-content-sm-end">
+                <a href="{{ url_for('admin.departments') }}" class="btn btn-outline-secondary">Cancel</a>
+                <button type="submit" class="btn btn-primary">
+                    {{ department and 'Update Department' or 'Create Department' }}
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.querySelector('form');
+    form.addEventListener('submit', function (event) {
+        if (!form.checkValidity()) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+        form.classList.add('was-validated');
+    });
+});
+</script>
+{% endblock %}

--- a/templates/admin/departments/index.html
+++ b/templates/admin/departments/index.html
@@ -1,0 +1,96 @@
+{% extends "admin/base.html" %}
+
+{% block admin_content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1>Ministry Departments</h1>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <a href="{{ url_for('admin.create_department') }}" class="btn btn-sm btn-outline-primary">
+            <i class="bi bi-plus-circle"></i> New Department
+        </a>
+    </div>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+{% endwith %}
+
+<div class="card">
+    <div class="card-body">
+        {% if departments %}
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col">Name</th>
+                            <th scope="col">Staff Lead</th>
+                            <th scope="col">Volunteer Roles</th>
+                            <th scope="col">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for department in departments %}
+                            <tr>
+                                <td>
+                                    <a href="{{ url_for('admin.department_detail', department_id=department.id) }}"
+                                       class="text-decoration-none fw-semibold">
+                                        {{ department.name }}
+                                    </a>
+                                    {% if department.description %}
+                                        <div class="text-muted small">{{ department.description|truncate(80) }}</div>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if department.lead %}
+                                        <span class="badge bg-secondary">{{ department.lead.username }}</span>
+                                    {% else %}
+                                        <span class="text-muted">Unassigned</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <span class="badge bg-light text-dark">{{ department.roles|length }}</span>
+                                </td>
+                                <td>
+                                    <div class="btn-group" role="group">
+                                        <a href="{{ url_for('admin.department_detail', department_id=department.id) }}"
+                                           class="btn btn-sm btn-outline-secondary" title="View">
+                                            <i class="bi bi-eye"></i>
+                                        </a>
+                                        <a href="{{ url_for('admin.edit_department', department_id=department.id) }}"
+                                           class="btn btn-sm btn-outline-primary" title="Edit">
+                                            <i class="bi bi-pencil"></i>
+                                        </a>
+                                        <form action="{{ url_for('admin.delete_department', department_id=department.id) }}"
+                                              method="POST" class="d-inline"
+                                              onsubmit="return confirm('Delete this department? This will remove associated roles.');">
+                                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete">
+                                                <i class="bi bi-trash"></i>
+                                            </button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <div class="text-center py-5">
+                <i class="bi bi-diagram-3 display-1 text-muted mb-3"></i>
+                <h5 class="text-muted">No departments configured</h5>
+                <p class="text-muted">Create a department to organise your serving teams.</p>
+                <a href="{{ url_for('admin.create_department') }}" class="btn btn-primary">
+                    <i class="bi bi-plus-circle"></i> Add Department
+                </a>
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/departments/role_form.html
+++ b/templates/admin/departments/role_form.html
@@ -1,0 +1,76 @@
+{% extends "admin/base.html" %}
+
+{% block admin_content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1>{{ role and 'Edit Volunteer Role' or 'Create Volunteer Role' }}</h1>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+{% endwith %}
+
+<div class="card">
+    <div class="card-body">
+        <form method="POST" class="needs-validation" novalidate>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="mb-3">
+                <label class="form-label">Department</label>
+                <input type="text" class="form-control" value="{{ department.name }}" disabled>
+                <div class="form-text">Volunteer roles must belong to a specific ministry department.</div>
+            </div>
+            <div class="mb-3">
+                <label for="name" class="form-label">Role Name</label>
+                <input type="text" class="form-control" id="name" name="name"
+                       value="{{ role.name if role }}" required>
+                <div class="invalid-feedback">Please provide a role name.</div>
+            </div>
+            <div class="mb-3">
+                <label for="description" class="form-label">Description</label>
+                <textarea class="form-control" id="description" name="description" rows="4"
+                          placeholder="Describe responsibilities and expectations">{{ role.description if role }}</textarea>
+            </div>
+            <div class="mb-4">
+                <label for="coordinator_id" class="form-label">Lay Coordinator</label>
+                <select class="form-select" id="coordinator_id" name="coordinator_id">
+                    <option value="">-- No coordinator assigned --</option>
+                    {% for user in users %}
+                        <option value="{{ user.id }}" {% if role and role.coordinator_id == user.id %}selected{% endif %}>
+                            {{ user.username }} ({{ user.email }})
+                        </option>
+                    {% endfor %}
+                </select>
+                <div class="form-text">Coordinate scheduling and communications for this team.</div>
+            </div>
+            <div class="d-grid gap-2 d-sm-flex justify-content-sm-end">
+                <a href="{{ url_for('admin.department_detail', department_id=department.id) }}" class="btn btn-outline-secondary">Cancel</a>
+                <button type="submit" class="btn btn-primary">
+                    {{ role and 'Update Role' or 'Create Role' }}
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.querySelector('form');
+    form.addEventListener('submit', function (event) {
+        if (!form.checkValidity()) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+        form.classList.add('was-validated');
+    });
+});
+</script>
+{% endblock %}

--- a/templates/admin/event_form.html
+++ b/templates/admin/event_form.html
@@ -88,6 +88,37 @@ main
                 </div>
             </div>
 
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="mb-3">
+                        <label for="department_id" class="form-label">Department / Team</label>
+                        <select class="form-select" id="department_id" name="department_id">
+                            <option value="">-- No team assigned --</option>
+                            {% for department in departments %}
+                                <option value="{{ department.id }}" {% if event and event.department_id == department.id %}selected{% endif %}>
+                                    {{ department.name }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                        <div class="form-text">Link this event to the ministry team responsible for delivery.</div>
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="mb-3">
+                        <label for="volunteer_role_id" class="form-label">Serving Role</label>
+                        <select class="form-select" id="volunteer_role_id" name="volunteer_role_id">
+                            <option value="">-- No serving role assigned --</option>
+                            {% for role in roles %}
+                                <option value="{{ role.id }}" {% if event and event.volunteer_role_id == role.id %}selected{% endif %}>
+                                    {{ role.name }}{% if role.department %} ({{ role.department.name }}){% endif %}
+                                </option>
+                            {% endfor %}
+                        </select>
+                        <div class="form-text">Coordinators attached to the selected role will appear on event pages.</div>
+                    </div>
+                </div>
+            </div>
+
             <div class="mb-4">
                 <label for="location" class="form-label">Location</label>
                 <input type="text" class="form-control" id="location" name="location"

--- a/templates/admin/events.html
+++ b/templates/admin/events.html
@@ -33,6 +33,8 @@
                             <th>Start Date</th>
                             <th>End Date</th>
                             <th>Location</th>
+                            <th>Team</th>
+                            <th>Coordinator</th>
                             <th>Status</th>
                             <th>Actions</th>
                         </tr>
@@ -44,6 +46,22 @@
                                 <td>{{ event.start_date.strftime('%Y-%m-%d %H:%M') }}</td>
                                 <td>{{ event.end_date.strftime('%Y-%m-%d %H:%M') }}</td>
                                 <td>{{ event.location }}</td>
+                                <td>
+                                    {% if event.department %}
+                                        {{ event.department.name }}
+                                    {% else %}
+                                        <span class="text-muted">Unassigned</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if event.volunteer_role and event.volunteer_role.coordinator %}
+                                        {{ event.volunteer_role.coordinator.username }}
+                                    {% elif event.department and event.department.lead %}
+                                        {{ event.department.lead.username }}
+                                    {% else %}
+                                        <span class="text-muted">N/A</span>
+                                    {% endif %}
+                                </td>
                                 <td>
                                     {% if event.end_date < now %}
                                         <span class="badge bg-secondary">Past</span>

--- a/templates/admin/volunteers/form.html
+++ b/templates/admin/volunteers/form.html
@@ -1,0 +1,92 @@
+{% extends "admin/base.html" %}
+
+{% block admin_content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1>{{ assignment and 'Edit Volunteer Assignment' or 'Assign Volunteer' }}</h1>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+{% endwith %}
+
+<div class="card">
+    <div class="card-body">
+        <form method="POST" class="needs-validation" novalidate>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="volunteer_id" class="form-label">Volunteer</label>
+                    <select class="form-select" id="volunteer_id" name="volunteer_id" required>
+                        <option value="">-- Select volunteer --</option>
+                        {% for volunteer in volunteers %}
+                            <option value="{{ volunteer.id }}" {% if assignment and assignment.volunteer_id == volunteer.id %}selected{% endif %}>
+                                {{ volunteer.username }} ({{ volunteer.email }})
+                            </option>
+                        {% endfor %}
+                    </select>
+                    <div class="invalid-feedback">Please choose a volunteer.</div>
+                </div>
+                <div class="col-md-6">
+                    <label for="role_id" class="form-label">Serving Role</label>
+                    <select class="form-select" id="role_id" name="role_id" required>
+                        <option value="">-- Select role --</option>
+                        {% for role in roles %}
+                            <option value="{{ role.id }}" {% if assignment and assignment.role_id == role.id %}selected{% endif %}>
+                                {{ role.department.name }} &mdash; {{ role.name }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                    <div class="invalid-feedback">Please choose a serving role.</div>
+                </div>
+            </div>
+            <div class="row g-3 mt-1">
+                <div class="col-md-6">
+                    <label for="start_date" class="form-label">Serving Since</label>
+                    <input type="date" class="form-control" id="start_date" name="start_date"
+                           value="{{ assignment.start_date.strftime('%Y-%m-%d') if assignment and assignment.start_date }}">
+                </div>
+                <div class="col-md-6">
+                    <label for="end_date" class="form-label">Serving Through</label>
+                    <input type="date" class="form-control" id="end_date" name="end_date"
+                           value="{{ assignment.end_date.strftime('%Y-%m-%d') if assignment and assignment.end_date }}">
+                    <div class="form-text">Leave blank for open-ended service.</div>
+                </div>
+            </div>
+            <div class="mt-3 mb-4">
+                <label for="notes" class="form-label">Notes</label>
+                <textarea class="form-control" id="notes" name="notes" rows="3"
+                          placeholder="e.g. weekly availability, special skills">{{ assignment.notes if assignment }}</textarea>
+            </div>
+            <div class="d-grid gap-2 d-sm-flex justify-content-sm-end">
+                <a href="{{ url_for('admin.volunteers') }}" class="btn btn-outline-secondary">Cancel</a>
+                <button type="submit" class="btn btn-primary">
+                    {{ assignment and 'Update Assignment' or 'Create Assignment' }}
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.querySelector('form');
+    form.addEventListener('submit', function (event) {
+        if (!form.checkValidity()) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+        form.classList.add('was-validated');
+    });
+});
+</script>
+{% endblock %}

--- a/templates/admin/volunteers/index.html
+++ b/templates/admin/volunteers/index.html
@@ -1,0 +1,103 @@
+{% extends "admin/base.html" %}
+
+{% block admin_content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1>Volunteer Assignments</h1>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <a href="{{ url_for('admin.create_volunteer_assignment') }}" class="btn btn-sm btn-outline-primary">
+            <i class="bi bi-person-plus"></i> Assign Volunteer
+        </a>
+    </div>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+{% endwith %}
+
+<div class="card">
+    <div class="card-body">
+        {% if assignments %}
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col">Volunteer</th>
+                            <th scope="col">Role</th>
+                            <th scope="col">Department</th>
+                            <th scope="col">Coordinator</th>
+                            <th scope="col">Serving Since</th>
+                            <th scope="col">Notes</th>
+                            <th scope="col">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for assignment in assignments %}
+                            <tr>
+                                <td>
+                                    <div class="fw-semibold">{{ assignment.volunteer.username }}</div>
+                                    <div class="text-muted small">{{ assignment.volunteer.email }}</div>
+                                </td>
+                                <td>{{ assignment.role.name }}</td>
+                                <td>{{ assignment.role.department.name }}</td>
+                                <td>
+                                    {% if assignment.role.coordinator %}
+                                        {{ assignment.role.coordinator.username }}
+                                    {% else %}
+                                        <span class="text-muted">Unassigned</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if assignment.start_date %}
+                                        {{ assignment.start_date.strftime('%b %d, %Y') }}
+                                    {% else %}
+                                        <span class="text-muted">Not set</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if assignment.notes %}
+                                        <span class="text-muted">{{ assignment.notes }}</span>
+                                    {% else %}
+                                        <span class="text-muted">&mdash;</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <div class="btn-group" role="group">
+                                        <a href="{{ url_for('admin.edit_volunteer_assignment', assignment_id=assignment.id) }}"
+                                           class="btn btn-sm btn-outline-primary" title="Edit">
+                                            <i class="bi bi-pencil"></i>
+                                        </a>
+                                        <form action="{{ url_for('admin.delete_volunteer_assignment', assignment_id=assignment.id) }}"
+                                              method="POST" class="d-inline"
+                                              onsubmit="return confirm('Remove this volunteer from the role?');">
+                                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete">
+                                                <i class="bi bi-trash"></i>
+                                            </button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <div class="text-center py-5">
+                <i class="bi bi-people display-1 text-muted mb-3"></i>
+                <h5 class="text-muted">No volunteer assignments yet</h5>
+                <p class="text-muted">Link volunteers to teams to coordinate event support.</p>
+                <a href="{{ url_for('admin.create_volunteer_assignment') }}" class="btn btn-primary">
+                    <i class="bi bi-person-plus"></i> Assign Volunteer
+                </a>
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/event_detail.html
+++ b/templates/event_detail.html
@@ -40,6 +40,57 @@
                 </div>
             </div>
 
+            {% if event.department or event.volunteer_role %}
+            <div class="card mb-4 shadow-sm">
+                <div class="card-body">
+                    <h2 class="h5 mb-3"><i class="bi bi-people me-2"></i>Serving Team</h2>
+                    {% if event.department %}
+                        <p class="mb-2"><strong>Department:</strong> {{ event.department.name }}</p>
+                        {% if event.department.lead %}
+                            <p class="text-muted mb-2">
+                                <i class="bi bi-person-badge me-2"></i>Staff Lead: {{ event.department.lead.username }}
+                            </p>
+                        {% endif %}
+                    {% endif %}
+                    {% if event.volunteer_role %}
+                        <p class="mb-2"><strong>Serving Role:</strong> {{ event.volunteer_role.name }}</p>
+                        <p class="text-muted mb-2">
+                            <i class="bi bi-person-lines-fill me-2"></i>
+                            Coordinator:
+                            {% if event.volunteer_role.coordinator %}
+                                {{ event.volunteer_role.coordinator.username }}
+                            {% elif event.department and event.department.lead %}
+                                {{ event.department.lead.username }}
+                            {% else %}
+                                To be announced
+                            {% endif %}
+                        </p>
+                        {% if event.volunteer_role.assignments %}
+                            <div class="mt-3">
+                                <h3 class="h6 text-uppercase text-muted">Serving Volunteers</h3>
+                                <ul class="list-unstyled mb-0">
+                                    {% for assignment in event.volunteer_role.assignments %}
+                                        <li class="d-flex align-items-center py-1">
+                                            <i class="bi bi-person-circle me-2"></i>
+                                            <span>{{ assignment.volunteer.username }}</span>
+                                            {% if assignment.start_date %}
+                                                <small class="text-muted ms-2">since {{ assignment.start_date.strftime('%b %Y') }}</small>
+                                            {% endif %}
+                                            {% if assignment.notes %}
+                                                <small class="text-muted ms-2">&mdash; {{ assignment.notes }}</small>
+                                            {% endif %}
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                        {% else %}
+                            <p class="text-muted mb-0">Volunteers are being scheduled for this role.</p>
+                        {% endif %}
+                    {% endif %}
+                </div>
+            </div>
+            {% endif %}
+
             <div class="d-flex flex-wrap gap-2 mb-5">
                 <a href="{{ url_for('events.events') }}" class="btn btn-secondary">
                     <i class="bi bi-arrow-left"></i> Back to Events

--- a/templates/events.html
+++ b/templates/events.html
@@ -39,7 +39,40 @@
                                     {{ event.location or 'Location TBA' }}
                                 </small>
                             </p>
-                            <a href="{{ url_for('events.event_detail', event_id=event.id) }}" 
+                            {% if event.department %}
+                            <p class="card-text">
+                                <small class="text-muted">
+                                    <i class="bi bi-people me-2"></i>Team:
+                                    {{ event.department.name }}
+                                    {% if event.department.lead %}
+                                        <span class="ms-1">(Lead: {{ event.department.lead.username }})</span>
+                                    {% endif %}
+                                </small>
+                            </p>
+                            {% endif %}
+                            {% if event.volunteer_role %}
+                            <p class="card-text">
+                                <small class="text-muted">
+                                    <i class="bi bi-person-badge me-2"></i>Coordinator:
+                                    {% if event.volunteer_role.coordinator %}
+                                        {{ event.volunteer_role.coordinator.username }}
+                                    {% elif event.department and event.department.lead %}
+                                        {{ event.department.lead.username }}
+                                    {% else %}
+                                        To be announced
+                                    {% endif %}
+                                </small>
+                            </p>
+                            {% if event.volunteer_role.assignments %}
+                            <p class="card-text">
+                                <small class="text-muted">
+                                    <i class="bi bi-people-fill me-2"></i>
+                                    {{ event.volunteer_role.assignments|length }} volunteer{{ event.volunteer_role.assignments|length != 1 and 's' or '' }} serving
+                                </small>
+                            </p>
+                            {% endif %}
+                            {% endif %}
+                            <a href="{{ url_for('events.event_detail', event_id=event.id) }}"
                                class="btn btn-outline-primary">
                                 Learn More
                             </a>


### PR DESCRIPTION
## Summary
- add ministry department, volunteer role, and volunteer assignment models while linking events to teams
- implement admin CRUD views and templates for departments, roles, and volunteer assignments and update navigation
- surface serving teams and coordinators in admin event forms plus public listings and detail pages

## Testing
- `pytest` *(fails: Invalid value in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1b9a38ec8333a2af0bb513e16e11