### PR TITLE
Add member management and assimilation tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,86 +1,68 @@
-from flask import Flask, render_template, request, g, session, redirect, url_for
-from flask_sqlalchemy import SQLAlchemy
+import logging
+import os
+from datetime import datetime
+
+from flask import Flask
+from flask_cors import CORS
 from flask_login import LoginManager
 from flask_mail import Mail
+from flask_sqlalchemy import SQLAlchemy
 from flask_wtf import CSRFProtect
-codex/explain-requested-code-functionality-dxdu2u
-from flask_cors import CORS
 from redis import Redis
 from rq import Queue
-from redis import Redis
-from rq import Queue
-import os
-main
-from datetime import datetime
-import logging
+
 from config import Config
+
 
 db = SQLAlchemy()
 login_manager = LoginManager()
 mail = Mail()
 csrf = CSRFProtect()
-codex/explain-requested-code-functionality-dxdu2u
 cors = CORS()
-redis_conn = Redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379/0"))
+redis_conn = Redis.from_url(os.getenv('REDIS_URL', 'redis://localhost:6379/0'))
 task_queue = Queue(connection=redis_conn)
-main
 
-def create_app():
+
+def create_app() -> Flask:
     app = Flask(__name__)
     app.config.from_object(Config)
 
-    # Configure logging
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger('covenant_connect')
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    ))
-    logger.addHandler(handler)
-codex/explain-requested-code-functionality-dxdu2u
 
-    if Config.SECRET_KEY == 'dev-secret-key':
-        logger.warning('SECRET_KEY is not set. Using development key.')
-    
-    # Configure database
     database_url = os.getenv('DATABASE_URL', 'sqlite:///app.db')
     if not database_url:
         raise RuntimeError('DATABASE_URL is not set')
     app.config['SQLALCHEMY_DATABASE_URI'] = database_url
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
-    # Configure secret key
-    secret_key = os.getenv('SECRET_KEY')
-    if not secret_key:
-        secret_key = 'dev-secret-key'
+    secret_key = os.getenv('SECRET_KEY') or 'dev-secret-key'
+    if secret_key == 'dev-secret-key':
         logger.warning('SECRET_KEY is not set. Using development key.')
     app.config['SECRET_KEY'] = secret_key
 
-    # Email configuration
     app.config['MAIL_SERVER'] = os.getenv('MAIL_SERVER', 'smtp.gmail.com')
     app.config['MAIL_PORT'] = int(os.getenv('MAIL_PORT', 587))
     app.config['MAIL_USE_TLS'] = os.getenv('MAIL_USE_TLS', 'true').lower() == 'true'
     app.config['MAIL_USERNAME'] = os.getenv('MAIL_USERNAME')
     app.config['MAIL_PASSWORD'] = os.getenv('MAIL_PASSWORD')
     app.config['MAIL_DEFAULT_SENDER'] = os.getenv('MAIL_DEFAULT_SENDER')
-main
 
-    # Initialize extensions
     db.init_app(app)
     login_manager.init_app(app)
     mail.init_app(app)
     csrf.init_app(app)
-codex/explain-requested-code-functionality-dxdu2u
-    cors.init_app(app, resources={r"/*": {"origins": app.config['CORS_ORIGINS']}})
- main
+    cors.init_app(app, resources={r"/*": {"origins": app.config.get('CORS_ORIGINS', '*')}})
+
     login_manager.login_view = 'auth.login'
-    app.task_queue = task_queue
 
-    # Initialize task queue lazily
-    redis_conn = Redis.from_url(app.config['REDIS_URL'])
-    app.task_queue = Queue(connection=redis_conn)
+    redis_url = app.config.get('REDIS_URL', os.getenv('REDIS_URL', 'redis://localhost:6379/0'))
+    redis_connection = Redis.from_url(redis_url)
+    app.task_queue = Queue(connection=redis_connection)
 
-    # Register blueprints
+    global task_queue
+    task_queue = app.task_queue
+
     from routes.home import home_bp
     from routes.auth import auth_bp
     from routes.admin import admin_bp
@@ -90,12 +72,9 @@ codex/explain-requested-code-functionality-dxdu2u
     from routes.gallery import gallery_bp
     from routes.donations import donations_bp
     from routes.notifications import notifications_bp
- codex/find-current-location-in-codebase-aqxt07
-    from routes.solutions import solutions_bp
- codex/find-current-location-in-codebase-ntia0s
     from routes.solutions import solutions_bp
     from routes.internal import internal_bp
-     main
+
     app.register_blueprint(home_bp)
     app.register_blueprint(auth_bp)
     app.register_blueprint(admin_bp)
@@ -105,21 +84,17 @@ codex/explain-requested-code-functionality-dxdu2u
     app.register_blueprint(gallery_bp)
     app.register_blueprint(donations_bp)
     app.register_blueprint(notifications_bp)
- codex/find-current-location-in-codebase-aqxt07
-    app.register_blueprint(solutions_bp)
- codex/find-current-location-in-codebase-ntia0s
     app.register_blueprint(solutions_bp)
     app.register_blueprint(internal_bp)
-     main
-    # Context processors
+
     @app.context_processor
     def inject_year():
         return {'current_year': datetime.utcnow().year}
 
-    # Load user
     from models import User
+
     @login_manager.user_loader
-    def load_user(user_id):
+    def load_user(user_id: str) -> User | None:
         return db.session.get(User, int(user_id))
 
     return app

--- a/models.py
+++ b/models.py
@@ -11,12 +11,176 @@ class User(UserMixin, db.Model):
     password_hash = db.Column(db.String(256))
     is_admin = db.Column(db.Boolean, default=False)
     notification_preferences = db.Column(db.JSON, default=dict)
+    member_profile = db.relationship('Member', back_populates='user', uselist=False)
 
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)
 
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)
+
+
+class Household(db.Model):
+    __tablename__ = 'households'
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(150), nullable=False)
+    primary_email = db.Column(db.String(120))
+    primary_phone = db.Column(db.String(50))
+    address_line1 = db.Column(db.String(200))
+    address_line2 = db.Column(db.String(200))
+    city = db.Column(db.String(100))
+    state = db.Column(db.String(100))
+    postal_code = db.Column(db.String(20))
+    notes = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    members = db.relationship(
+        'Member',
+        back_populates='household',
+        cascade='all, delete-orphan',
+        order_by='Member.last_name',
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - representation helper
+        return f"<Household {self.name!r}>"
+
+
+class Member(db.Model):
+    __tablename__ = 'members'
+
+    DEFAULT_MILESTONES = [
+        ('first_visit', 'First Visit'),
+        ('next_steps', 'Next Steps Class'),
+        ('serve_team', 'Serving Team'),
+        ('community_group', 'Joined a Community Group'),
+        ('prayer_connection', 'Shared a Prayer Request'),
+        ('sermon_engagement', 'Engaged with a Sermon'),
+    ]
+
+    id = db.Column(db.Integer, primary_key=True)
+    first_name = db.Column(db.String(100), nullable=False)
+    last_name = db.Column(db.String(100))
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    phone = db.Column(db.String(50))
+    birth_date = db.Column(db.Date)
+    gender = db.Column(db.String(20))
+    marital_status = db.Column(db.String(50))
+    membership_status = db.Column(db.String(50), default='guest')
+    assimilation_stage = db.Column(db.String(100))
+    milestones = db.Column(db.JSON, default=dict)
+    notes = db.Column(db.Text)
+    preferred_contact_method = db.Column(db.String(50))
+    joined_at = db.Column(db.Date)
+    last_interaction_at = db.Column(db.DateTime)
+    next_follow_up_date = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
+    household_id = db.Column(db.Integer, db.ForeignKey('households.id'))
+
+    user = db.relationship('User', back_populates='member_profile')
+    household = db.relationship('Household', back_populates='members')
+    care_interactions = db.relationship(
+        'CareInteraction',
+        back_populates='member',
+        order_by='CareInteraction.interaction_date DESC',
+        cascade='all, delete-orphan',
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - representation helper
+        return f"<Member {self.full_name}>"
+
+    @property
+    def full_name(self) -> str:
+        return " ".join(filter(None, [self.first_name, self.last_name])).strip()
+
+    @property
+    def milestone_counts(self) -> tuple[int, int]:
+        data = self.milestones or {}
+        default_keys = [key for key, _ in self.DEFAULT_MILESTONES]
+
+        total = len(default_keys)
+        completed = 0
+
+        for key in default_keys:
+            if data.get(key, {}).get('completed'):
+                completed += 1
+
+        extra_keys = [key for key in data.keys() if key not in default_keys]
+        total += len(extra_keys)
+        for key in extra_keys:
+            if data.get(key, {}).get('completed'):
+                completed += 1
+
+        return completed, total
+
+    @property
+    def milestone_completion_rate(self) -> float:
+        completed, total = self.milestone_counts
+        if total == 0:
+            return 0.0
+        return completed / total
+
+    @property
+    def milestone_completion_percent(self) -> int:
+        return int(round(self.milestone_completion_rate * 100))
+
+    @property
+    def follow_up_due(self) -> bool:
+        if not self.next_follow_up_date:
+            return False
+        return self.next_follow_up_date.date() <= datetime.utcnow().date()
+
+    def record_milestone(
+        self,
+        key: str,
+        label: str | None = None,
+        *,
+        completed: bool = True,
+        completed_on: datetime | None = None,
+    ) -> None:
+        data = dict(self.milestones or {})
+        data[key] = {
+            'label': label or self.milestone_label(key),
+            'completed': completed,
+            'completed_on': (
+                (completed_on or datetime.utcnow()).isoformat()
+                if completed
+                else None
+            ),
+        }
+        self.milestones = data
+
+    @classmethod
+    def milestone_label(cls, key: str) -> str:
+        for default_key, default_label in cls.DEFAULT_MILESTONES:
+            if default_key == key:
+                return default_label
+        return key.replace('_', ' ').title()
+
+
+class CareInteraction(db.Model):
+    __tablename__ = 'care_interactions'
+
+    id = db.Column(db.Integer, primary_key=True)
+    member_id = db.Column(db.Integer, db.ForeignKey('members.id'), nullable=False)
+    interaction_type = db.Column(db.String(50), nullable=False)
+    interaction_date = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    notes = db.Column(db.Text)
+    follow_up_required = db.Column(db.Boolean, default=False)
+    follow_up_date = db.Column(db.DateTime)
+    created_by_id = db.Column(db.Integer, db.ForeignKey('users.id'))
+    source = db.Column(db.String(100))
+    metadata = db.Column(db.JSON, default=dict)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    member = db.relationship('Member', back_populates='care_interactions')
+    created_by = db.relationship('User', foreign_keys=[created_by_id])
+
+    def __repr__(self) -> str:  # pragma: no cover - representation helper
+        return f"<CareInteraction {self.interaction_type} for member {self.member_id}>"
 
 class PrayerRequest(db.Model):
     __tablename__ = 'prayer_requests'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ dependencies = [
     "redis>=5.2.0",
     "flask-wtf>=1.2.1",
     "rq>=1.16.2",
-codex/explain-requested-code-functionality-dxdu2u
     "flask-cors>=4.0.0",
     "python-dotenv>=1.0.1",
-main
 ]

--- a/routes/prayers.py
+++ b/routes/prayers.py
@@ -1,16 +1,68 @@
-from flask import Blueprint, render_template, request, flash, redirect, url_for, current_app
-codex/explain-requested-code-functionality-dxdu2u
-from app import db
+from datetime import datetime, timedelta
+
+from flask import Blueprint, current_app, flash, redirect, render_template, request, url_for
+from sqlalchemy import func
+from sqlalchemy.exc import SQLAlchemyError
+
 from app import db, task_queue
-main
-from models import PrayerRequest, User
+from models import CareInteraction, Member, PrayerRequest
 from tasks import send_prayer_notification
 
 prayers_bp = Blueprint('prayers', __name__)
 
+
+def _find_member_by_email(email: str | None) -> Member | None:
+    if not email:
+        return None
+    normalized = email.strip().lower()
+    if not normalized:
+        return None
+    return Member.query.filter(func.lower(Member.email) == normalized).first()
+
+
+def _record_prayer_interaction(member: Member, prayer: PrayerRequest, is_public: bool) -> None:
+    interaction_time = datetime.utcnow()
+    follow_up_required = not is_public
+    follow_up_date = interaction_time + timedelta(days=2) if follow_up_required else None
+
+    interaction = CareInteraction(
+        member=member,
+        interaction_type='prayer_request',
+        interaction_date=interaction_time,
+        notes=f'Prayer request submitted: {prayer.request[:200]}',
+        follow_up_required=follow_up_required,
+        follow_up_date=follow_up_date,
+        source='prayer_form',
+        metadata={'prayer_request_id': prayer.id, 'is_public': is_public},
+    )
+
+    member.last_interaction_at = interaction_time
+    if follow_up_required:
+        if not member.next_follow_up_date or follow_up_date < member.next_follow_up_date:
+            member.next_follow_up_date = follow_up_date
+    if 'prayer_connection' not in (member.milestones or {}):
+        member.record_milestone('prayer_connection', 'Shared a Prayer Request', completed=True)
+
+    db.session.add(interaction)
+
+
+def _enqueue_notification(prayer_id: int) -> None:
+    try:
+        if task_queue:
+            task_queue.enqueue(send_prayer_notification, prayer_id)
+        elif hasattr(current_app, 'task_queue') and current_app.task_queue:
+            current_app.task_queue.enqueue(send_prayer_notification, prayer_id)
+    except Exception as exc:  # pragma: no cover - background queue best effort
+        current_app.logger.warning(f"Unable to enqueue prayer notification: {exc}")
+
+
 @prayers_bp.route('/prayers', methods=['GET'])
 def prayers():
-    public_prayers = PrayerRequest.query.filter_by(is_public=True).order_by(PrayerRequest.created_at.desc()).all()
+    public_prayers = (
+        PrayerRequest.query.filter_by(is_public=True)
+        .order_by(PrayerRequest.created_at.desc())
+        .all()
+    )
     return render_template('prayers.html', prayers=public_prayers)
 
 
@@ -30,22 +82,29 @@ def submit_prayer():
             name=name,
             email=email,
             request=prayer_request,
-            is_public=is_public
+            is_public=is_public,
         )
-        
+
         db.session.add(new_prayer)
+        db.session.flush()
+
+        member = _find_member_by_email(email)
+        if member:
+            _record_prayer_interaction(member, new_prayer, is_public)
+
         db.session.commit()
-        
-        # Send email notification to admins
-codex/explain-requested-code-functionality-dxdu2u
-        current_app.task_queue.enqueue(send_prayer_notification, new_prayer.id)
-        task_queue.enqueue(send_prayer_notification, new_prayer.id)
-main
-        
+
+        _enqueue_notification(new_prayer.id)
+
         flash('Prayer request submitted successfully', 'success')
         return redirect(url_for('prayers.prayers'))
-    except Exception as e:
-        current_app.logger.error(f"Error submitting prayer request: {str(e)}")
+    except SQLAlchemyError as exc:
+        current_app.logger.error(f"Database error submitting prayer request: {exc}")
+        db.session.rollback()
+        flash('An error occurred while submitting your prayer request. Please try again.', 'error')
+        return redirect(url_for('prayers.prayers'))
+    except Exception as exc:
+        current_app.logger.error(f"Unexpected error submitting prayer request: {exc}")
         db.session.rollback()
         flash('An error occurred while submitting your prayer request. Please try again.', 'error')
         return redirect(url_for('prayers.prayers'))

--- a/routes/sermons.py
+++ b/routes/sermons.py
@@ -1,32 +1,17 @@
 from datetime import datetime
- codex/find-current-location-in-codebase-aqxt07
- codex/find-current-location-in-codebase-ntia0s
-from typing import Dict, Optional
-       main
+from typing import Optional
 from urllib.parse import parse_qs, urlparse
 
-from flask import (
-    Blueprint,
-    current_app,
-    flash,
-    redirect,
-    render_template,
-    request,
-    url_for,
-)
- codex/find-current-location-in-codebase-aqxt07
-from app import db
- codex/find-current-location-in-codebase-ntia0s
-from app import db
-       main
-from models import Sermon
+from flask import Blueprint, current_app, flash, redirect, render_template, request, url_for
+from flask_login import current_user
+from sqlalchemy import func
 from sqlalchemy.exc import SQLAlchemyError
 
+from app import db
+from models import CareInteraction, Member, Sermon
 
 sermons_bp = Blueprint('sermons', __name__)
 
-
- codex/find-current-location-in-codebase-aqxt07
 VIDEO_HOSTS = (
     'youtube.com',
     'youtu.be',
@@ -50,8 +35,7 @@ AUDIO_EXTENSIONS = (
 )
 
 
-def _infer_media_type(media_url: str) -> str | None:
-    """Guess the media type from known host names or file extensions."""
+def _infer_media_type(media_url: str) -> Optional[str]:
     parsed = urlparse(media_url)
     host = parsed.netloc.lower()
     path = parsed.path.lower()
@@ -68,54 +52,7 @@ def _infer_media_type(media_url: str) -> str | None:
     return None
 
 
-def _build_media_context(sermon: Sermon) -> dict[str, str | None]:
-    """Return template context for sermon media, inferring type when missing."""
-    media_type = (sermon.media_type or '').strip().lower()
- codex/find-current-location-in-codebase-ntia0s
-def _build_media_context(sermon: Sermon) -> dict[str, str | None]:
-def _build_media_context(sermon: Sermon) -> Dict[str, Optional[str]]:
-        main
-    """Return template-friendly context describing how to render sermon media."""
-    media_type = (sermon.media_type or '').lower()
-       main
-    media_url = (sermon.media_url or '').strip()
-
-    if not media_url:
-        return {"type": None, "embed_url": None, "source_url": None}
-
- codex/find-current-location-in-codebase-aqxt07
-    detected_media_type = media_type or (_infer_media_type(media_url) or '')
-
-    if detected_media_type == 'video':
-    if media_type == 'video':
-        main
-        embed_url = _resolve_video_embed(media_url)
-
-        return {
-            "type": 'video',
-            "embed_url": embed_url,
-            "source_url": media_url,
-        }
-
- codex/find-current-location-in-codebase-aqxt07
-    if detected_media_type == 'audio':
-    if media_type == 'audio':
-         main
-        return {
-            "type": 'audio',
-            "embed_url": media_url,
-            "source_url": media_url,
-        }
-
-    return {
-        "type": 'link',
-        "embed_url": None,
-        "source_url": media_url,
-    }
-
-
 def _resolve_video_embed(media_url: str) -> str:
-    """Convert known video providers into embeddable URLs when possible."""
     parsed = urlparse(media_url)
     host = parsed.netloc.lower()
 
@@ -140,21 +77,114 @@ def _resolve_video_embed(media_url: str) -> str:
     return media_url
 
 
+def _build_media_context(sermon: Sermon) -> dict[str, Optional[str]]:
+    media_type = (sermon.media_type or '').strip().lower()
+    media_url = (sermon.media_url or '').strip()
+
+    if not media_url:
+        return {"type": None, "embed_url": None, "source_url": None}
+
+    detected_media_type = media_type or (_infer_media_type(media_url) or '')
+
+    if detected_media_type == 'video':
+        embed_url = _resolve_video_embed(media_url)
+        return {
+            'type': 'video',
+            'embed_url': embed_url,
+            'source_url': media_url,
+        }
+
+    if detected_media_type == 'audio':
+        return {
+            'type': 'audio',
+            'embed_url': media_url,
+            'source_url': media_url,
+        }
+
+    return {
+        'type': 'link',
+        'embed_url': None,
+        'source_url': media_url,
+    }
+
+
+def _find_member_by_email(email: Optional[str]) -> Optional[Member]:
+    if not email:
+        return None
+    normalized = email.strip().lower()
+    if not normalized:
+        return None
+    return Member.query.filter(func.lower(Member.email) == normalized).first()
+
+
+def _resolve_member_for_engagement() -> Optional[Member]:
+    email_from_request = request.args.get('email')
+    member = _find_member_by_email(email_from_request)
+    if member:
+        return member
+
+    if current_user.is_authenticated:
+        profile = getattr(current_user, 'member_profile', None)
+        if profile:
+            return profile
+        return _find_member_by_email(getattr(current_user, 'email', None))
+
+    return None
+
+
+def _log_sermon_engagement(member: Member, sermon: Sermon) -> bool:
+    today = datetime.utcnow().date()
+    start_of_day = datetime(today.year, today.month, today.day)
+
+    recent_interactions = (
+        CareInteraction.query.filter(
+            CareInteraction.member_id == member.id,
+            CareInteraction.interaction_type == 'sermon_engagement',
+            CareInteraction.interaction_date >= start_of_day,
+        )
+        .order_by(CareInteraction.interaction_date.desc())
+        .all()
+    )
+
+    for interaction in recent_interactions:
+        metadata = interaction.metadata or {}
+        if metadata.get('sermon_id') == sermon.id:
+            return False
+
+    milestone_entry = (member.milestones or {}).get('sermon_engagement')
+    if not milestone_entry or not milestone_entry.get('completed'):
+        member.record_milestone('sermon_engagement', 'Engaged with a Sermon', completed=True)
+
+    interaction_time = datetime.utcnow()
+    interaction = CareInteraction(
+        member=member,
+        interaction_type='sermon_engagement',
+        interaction_date=interaction_time,
+        notes=f'Engaged with sermon "{sermon.title}"',
+        follow_up_required=False,
+        source='sermon_detail',
+        metadata={'sermon_id': sermon.id, 'sermon_title': sermon.title},
+    )
+
+    member.last_interaction_at = interaction_time
+    if not member.assimilation_stage:
+        member.assimilation_stage = 'Engaged Online'
+
+    db.session.add(interaction)
+    return True
+
+
 @sermons_bp.route('/sermons')
 def sermons():
-    """Display all sermons with optional search parameters."""
     try:
-        # Get search parameters
         title = request.args.get('title', '').strip()
         preacher = request.args.get('preacher', '').strip()
-        start_date = request.args.get('start_date', '')
-        end_date = request.args.get('end_date', '')
+        start_date = request.args.get('start_date', '').strip()
+        end_date = request.args.get('end_date', '').strip()
         media_type = request.args.get('media_type', '').strip()
 
-        # Build query
         query = Sermon.query
 
-        # Apply filters
         if title:
             query = query.filter(Sermon.title.ilike(f'%{title}%'))
         if preacher:
@@ -164,45 +194,32 @@ def sermons():
                 start_date_parsed = datetime.strptime(start_date, '%Y-%m-%d')
                 query = query.filter(Sermon.date >= start_date_parsed)
             except ValueError:
-                current_app.logger.warning(
-                    f"Invalid start_date format: {start_date}"
-                )
+                current_app.logger.warning(f"Invalid start_date format: {start_date}")
         if end_date:
             try:
                 end_date_parsed = datetime.strptime(end_date, '%Y-%m-%d')
                 query = query.filter(Sermon.date <= end_date_parsed)
             except ValueError:
-                current_app.logger.warning(
-                    f"Invalid end_date format: {end_date}"
-                )
+                current_app.logger.warning(f"Invalid end_date format: {end_date}")
         if media_type:
             query = query.filter(Sermon.media_type == media_type)
 
-        # Execute query with sorting
         sermons_list = query.order_by(Sermon.date.desc()).all()
         return render_template('sermons.html', sermons=sermons_list)
-
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - defensive fallback
         current_app.logger.error(f"Error in sermons route: {exc}")
         return render_template('sermons.html', sermons=[])
 
 
 @sermons_bp.route('/sermons/search')
 def search_sermons():
-    """Advanced search endpoint for sermons."""
-    return sermons()  # Reuse the main sermons route as it already handles search
+    return sermons()
 
 
 @sermons_bp.route('/sermons/<int:sermon_id>')
 def sermon_detail(sermon_id: int):
-    """Render the detail page for a specific sermon with related content."""
     try:
- codex/find-current-location-in-codebase-aqxt07
-        sermon = db.session.get(Sermon, sermon_id)
- codex/find-current-location-in-codebase-ntia0s
-        sermon = db.session.get(Sermon, sermon_id)
         sermon = Sermon.query.get(sermon_id)
-        main
         if not sermon:
             flash('Sermon not found.', 'warning')
             return redirect(url_for('sermons.sermons'))
@@ -216,6 +233,22 @@ def sermon_detail(sermon_id: int):
         )
 
         media_context = _build_media_context(sermon)
+
+        member = _resolve_member_for_engagement()
+        if member:
+            try:
+                if _log_sermon_engagement(member, sermon):
+                    db.session.commit()
+            except SQLAlchemyError as engagement_exc:
+                db.session.rollback()
+                current_app.logger.error(
+                    f"Database error logging sermon engagement for member {member.id}: {engagement_exc}"
+                )
+            except Exception as engagement_exc:  # pragma: no cover - safety net
+                db.session.rollback()
+                current_app.logger.error(
+                    f"Unexpected error logging sermon engagement for member {member.id}: {engagement_exc}"
+                )
 
         return render_template(
             'sermon_detail.html',

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -8,21 +8,28 @@
             <div class="sidebar-sticky">
                 <ul class="nav flex-column">
                     <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.dashboard' %}active{% endif %}" 
+                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.dashboard' %}active{% endif %}"
                            href="{{ url_for('admin.dashboard') }}">
                             <i class="bi bi-speedometer2"></i>
                             <span>Dashboard</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.users' %}active{% endif %}" 
+                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.users' %}active{% endif %}"
                            href="{{ url_for('admin.users') }}">
                             <i class="bi bi-people"></i>
                             <span>Users</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.events' %}active{% endif %}" 
+                        <a class="nav-link d-flex align-items-center {% if request.endpoint in ['admin.members', 'admin.member_profile', 'admin.log_member_follow_up'] %}active{% endif %}"
+                           href="{{ url_for('admin.members') }}">
+                            <i class="bi bi-person-heart"></i>
+                            <span>Members</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.events' %}active{% endif %}"
                            href="{{ url_for('admin.events') }}">
                             <i class="bi bi-calendar-event"></i>
                             <span>Events</span>

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -127,10 +127,50 @@
             </div>
         </div>
     </div>
+
+    <!-- Member Care Stats -->
+    <div class="col-md-6 col-xl-3">
+        <div class="card h-100 dashboard-card">
+            <div class="card-body">
+                <div class="d-flex align-items-center">
+                    <div class="flex-shrink-0">
+                        <div class="stat-icon bg-secondary bg-opacity-10 rounded p-3">
+                            <i class="bi bi-people-heart fs-3 text-secondary"></i>
+                        </div>
+                    </div>
+                    <div class="flex-grow-1 ms-3">
+                        <h6 class="card-subtitle mb-2 text-muted">Member Care</h6>
+                        <h3 class="card-title mb-0">{{ member_stats.total }}</h3>
+                    </div>
+                </div>
+                <hr>
+                <div class="row text-center">
+                    <div class="col">
+                        <small class="text-muted d-block">Connected</small>
+                        <span class="h5">{{ member_stats.connected }}</span>
+                    </div>
+                    <div class="col">
+                        <small class="text-muted d-block">Follow-ups Due</small>
+                        <span class="h5">{{ member_stats.followups_due }}</span>
+                    </div>
+                </div>
+                <div class="mt-3">
+                    <small class="text-muted d-block mb-1">Avg. Milestone Completion</small>
+                    <div class="progress" style="height: 6px;">
+                        <div class="progress-bar bg-secondary" role="progressbar"
+                             style="width: {{ member_stats.milestone_completion_rate }}%;"
+                             aria-valuenow="{{ member_stats.milestone_completion_rate }}" aria-valuemin="0" aria-valuemax="100">
+                        </div>
+                    </div>
+                    <div class="text-end small text-muted mt-1">{{ member_stats.milestone_completion_rate }}%</div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
-<div class="row mt-4">
-    <div class="col-12">
+<div class="row mt-4 g-4">
+    <div class="col-lg-6">
         <div class="card dashboard-card">
             <div class="card-header">
                 <h5 class="card-title mb-0">Quick Actions</h5>
@@ -158,6 +198,43 @@
                         </a>
                     </div>
                 </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-6">
+        <div class="card dashboard-card h-100">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h5 class="card-title mb-0">Recent Care Follow-ups</h5>
+                <a href="{{ url_for('admin.members') }}" class="btn btn-sm btn-outline-primary">View All</a>
+            </div>
+            <div class="card-body p-0">
+                {% if recent_followups %}
+                    <ul class="list-group list-group-flush">
+                        {% for interaction in recent_followups %}
+                            <li class="list-group-item">
+                                <div class="d-flex justify-content-between align-items-start">
+                                    <div>
+                                        <strong>{{ interaction.member.full_name }}</strong>
+                                        <div class="small text-muted">{{ interaction.interaction_type.replace('_', ' ')|title }}</div>
+                                    </div>
+                                    <div class="text-end">
+                                        <div class="small text-muted">{{ interaction.interaction_date.strftime('%b %d, %Y') }}</div>
+                                        {% if interaction.created_by %}
+                                            <div class="small text-muted">by {{ interaction.created_by.username }}</div>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                                {% if interaction.notes %}
+                                    <div class="small mt-2 text-muted">{{ interaction.notes }}</div>
+                                {% endif %}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <div class="p-4 text-center text-muted">
+                        No follow-up activity recorded yet.
+                    </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/templates/admin/members/detail.html
+++ b/templates/admin/members/detail.html
@@ -1,0 +1,212 @@
+{% extends "admin/base.html" %}
+
+{% block admin_content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <div>
+        <h1 class="h2 mb-0">{{ member.full_name }}</h1>
+        <p class="text-muted mb-0">{{ member.membership_status|default('Guest', true)|title }} &middot; {{ member.email }}</p>
+    </div>
+    <div class="text-md-end mt-3 mt-md-0">
+        {% if member.follow_up_due %}
+            <span class="badge bg-warning text-dark">Follow-up Due</span>
+        {% endif %}
+        <a href="{{ url_for('admin.members') }}" class="btn btn-outline-secondary ms-2">Back to Members</a>
+    </div>
+</div>
+
+<div class="row g-4">
+    <div class="col-lg-4">
+        <div class="card shadow-sm mb-4">
+            <div class="card-header">
+                <h2 class="h6 mb-0">Profile Summary</h2>
+            </div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    <dt class="col-6 small text-muted">Assimilation Stage</dt>
+                    <dd class="col-6 fw-semibold">{{ member.assimilation_stage or 'New Connection' }}</dd>
+                    <dt class="col-6 small text-muted">Preferred Contact</dt>
+                    <dd class="col-6">{{ member.preferred_contact_method or 'Not set' }}</dd>
+                    <dt class="col-6 small text-muted">Phone</dt>
+                    <dd class="col-6">{{ member.phone or 'Not set' }}</dd>
+                    <dt class="col-6 small text-muted">Last Interaction</dt>
+                    <dd class="col-6">{% if member.last_interaction_at %}{{ member.last_interaction_at.strftime('%b %d, %Y') }}{% else %}None yet{% endif %}</dd>
+                    <dt class="col-6 small text-muted">Next Follow-up</dt>
+                    <dd class="col-6">{% if member.next_follow_up_date %}{{ member.next_follow_up_date.strftime('%b %d, %Y') }}{% else %}Not scheduled{% endif %}</dd>
+                </dl>
+            </div>
+        </div>
+
+        <div class="card shadow-sm mb-4">
+            <div class="card-header">
+                <h2 class="h6 mb-0">Milestones</h2>
+            </div>
+            <div class="card-body">
+                {% set milestone_data = member.milestones or {} %}
+                <ul class="list-group list-group-flush">
+                    {% for key, label in milestone_catalog %}
+                        {% set record = milestone_data.get(key) %}
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            <div>
+                                <div class="fw-semibold">{{ label }}</div>
+                                {% if record and record.completed_on %}
+                                    <div class="small text-muted">Completed {{ record.completed_on|replace('T', ' ') }}</div>
+                                {% endif %}
+                            </div>
+                            {% if record and record.completed %}
+                                <span class="badge bg-success">Completed</span>
+                            {% else %}
+                                <span class="badge bg-light text-muted">Pending</span>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                    {% for key, record in extra_milestones %}
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            <div>
+                                <div class="fw-semibold">{{ member.milestone_label(key) }}</div>
+                                {% if record.completed_on %}
+                                    <div class="small text-muted">Completed {{ record.completed_on|replace('T', ' ') }}</div>
+                                {% endif %}
+                            </div>
+                            {% if record.completed %}
+                                <span class="badge bg-success">Completed</span>
+                            {% else %}
+                                <span class="badge bg-light text-muted">Pending</span>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+
+        {% if member.household %}
+            <div class="card shadow-sm">
+                <div class="card-header">
+                    <h2 class="h6 mb-0">Household</h2>
+                </div>
+                <div class="card-body">
+                    <h3 class="h6">{{ member.household.name }}</h3>
+                    <p class="small mb-2 text-muted">{{ member.household.primary_email or 'No email on file' }}</p>
+                    {% if member.household.primary_phone %}
+                        <p class="small mb-2"><i class="bi bi-telephone me-2"></i>{{ member.household.primary_phone }}</p>
+                    {% endif %}
+                    {% if member.household.address_line1 %}
+                        <p class="small mb-0">{{ member.household.address_line1 }}<br>
+                        {% if member.household.address_line2 %}{{ member.household.address_line2 }}<br>{% endif %}
+                        {{ member.household.city }}, {{ member.household.state }} {{ member.household.postal_code }}</p>
+                    {% endif %}
+                </div>
+            </div>
+        {% endif %}
+    </div>
+
+    <div class="col-lg-8">
+        <div class="card shadow-sm mb-4">
+            <div class="card-header">
+                <h2 class="h6 mb-0">Log a Follow-up</h2>
+            </div>
+            <div class="card-body">
+                <form method="post" action="{{ url_for('admin.log_member_follow_up', member_id=member.id) }}">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label for="interaction_type" class="form-label">Interaction Type</label>
+                            <select class="form-select" id="interaction_type" name="interaction_type">
+                                <option value="phone_call">Phone Call</option>
+                                <option value="text_message">Text Message</option>
+                                <option value="email">Email</option>
+                                <option value="meeting">In-person Meeting</option>
+                                <option value="prayer_follow_up">Prayer Follow-up</option>
+                                <option value="sermon_engagement">Sermon Engagement</option>
+                                <option value="other">Other</option>
+                            </select>
+                        </div>
+                        <div class="col-md-3">
+                            <label for="interaction_date" class="form-label">Interaction Date</label>
+                            <input type="date" class="form-control" id="interaction_date" name="interaction_date">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Follow-up Required</label>
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" role="switch" id="follow_up_required" name="follow_up_required" {% if member.follow_up_due %}checked{% endif %}>
+                                <label class="form-check-label" for="follow_up_required">Yes</label>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="follow_up_date" class="form-label">Next Follow-up Date</label>
+                            <input type="date" class="form-control" id="follow_up_date" name="follow_up_date" value="{% if member.next_follow_up_date %}{{ member.next_follow_up_date.strftime('%Y-%m-%d') }}{% endif %}">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="membership_status" class="form-label">Membership Status</label>
+                            <select class="form-select" id="membership_status" name="membership_status">
+                                <option value="">Keep current</option>
+                                {% set current_status = member.membership_status or '' %}
+                                {% for option in ['guest', 'attender', 'regular', 'member', 'partner'] %}
+                                    <option value="{{ option }}" {% if current_status == option %}selected{% endif %}>{{ option|title }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="assimilation_stage" class="form-label">Assimilation Stage</label>
+                            <input type="text" class="form-control" id="assimilation_stage" name="assimilation_stage" value="{{ member.assimilation_stage or '' }}" placeholder="e.g., Growth Track">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="milestone_key" class="form-label">Update Milestone</label>
+                            <select class="form-select" id="milestone_key" name="milestone_key">
+                                <option value="">No milestone update</option>
+                                {% for key, label in milestone_catalog %}
+                                    <option value="{{ key }}">{{ label }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-6 d-flex align-items-end">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="milestone_completed" name="milestone_completed">
+                                <label class="form-check-label" for="milestone_completed">Mark milestone as completed</label>
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <label for="notes" class="form-label">Notes</label>
+                            <textarea class="form-control" id="notes" name="notes" rows="4" placeholder="Capture details from your interaction"></textarea>
+                        </div>
+                    </div>
+                    <div class="mt-4 text-end">
+                        <button type="submit" class="btn btn-primary">Save Follow-up</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <div class="card shadow-sm">
+            <div class="card-header">
+                <h2 class="h6 mb-0">Interaction History</h2>
+            </div>
+            <div class="card-body p-0">
+                {% if interactions %}
+                    <ul class="list-group list-group-flush">
+                        {% for interaction in interactions %}
+                            <li class="list-group-item">
+                                <div class="d-flex justify-content-between align-items-start">
+                                    <div>
+                                        <div class="fw-semibold">{{ interaction.interaction_type.replace('_', ' ')|title }}</div>
+                                        <div class="small text-muted">
+                                            {{ interaction.interaction_date.strftime('%B %d, %Y') }}
+                                            {% if interaction.created_by %}&middot; Logged by {{ interaction.created_by.username }}{% endif %}
+                                        </div>
+                                    </div>
+                                    {% if interaction.follow_up_required and interaction.follow_up_date %}
+                                        <span class="badge bg-warning text-dark">Follow up {{ interaction.follow_up_date.strftime('%b %d') }}</span>
+                                    {% endif %}
+                                </div>
+                                {% if interaction.notes %}
+                                    <p class="small mb-0 mt-2">{{ interaction.notes }}</p>
+                                {% endif %}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <div class="p-4 text-center text-muted">No follow-up activity recorded yet. Use the form above to log your first interaction.</div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/members/index.html
+++ b/templates/admin/members/index.html
@@ -1,0 +1,107 @@
+{% extends "admin/base.html" %}
+
+{% block admin_content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <div>
+        <h1 class="h2 mb-0">Members</h1>
+        <p class="text-muted mb-0">Track assimilation progress and care follow-ups for your community.</p>
+    </div>
+</div>
+
+<form method="get" class="row g-3 align-items-end mb-4">
+    <div class="col-md-4">
+        <label for="search" class="form-label">Search</label>
+        <input type="text" class="form-control" id="search" name="q" placeholder="Search by name or email" value="{{ search }}">
+    </div>
+    <div class="col-md-3">
+        <label for="status" class="form-label">Membership Status</label>
+        <select class="form-select" id="status" name="status">
+            <option value="">All statuses</option>
+            {% for status in statuses %}
+                <option value="{{ status }}" {% if status_filter == status %}selected{% endif %}>{{ status|title }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">&nbsp;</label>
+        <div class="d-flex gap-2">
+            <button type="submit" class="btn btn-primary">Filter</button>
+            <a href="{{ url_for('admin.members') }}" class="btn btn-outline-secondary">Reset</a>
+        </div>
+    </div>
+</form>
+
+<div class="card shadow-sm">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h2 class="h5 mb-0">Tracked Members</h2>
+        <span class="badge bg-primary bg-opacity-25 text-primary">{{ members|length }} members</span>
+    </div>
+    <div class="table-responsive">
+        <table class="table align-middle mb-0">
+            <thead class="table-light">
+                <tr>
+                    <th scope="col">Member</th>
+                    <th scope="col">Contact</th>
+                    <th scope="col">Stage</th>
+                    <th scope="col">Milestones</th>
+                    <th scope="col">Next Follow-up</th>
+                    <th scope="col">Last Interaction</th>
+                    <th scope="col" class="text-end">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% if members %}
+                    {% for member in members %}
+                        {% set completed, total = member.milestone_counts %}
+                        <tr>
+                            <td>
+                                <div class="fw-semibold"><a href="{{ url_for('admin.member_profile', member_id=member.id) }}" class="text-decoration-none">{{ member.full_name }}</a></div>
+                                <div class="small text-muted text-capitalize">{{ member.membership_status or 'Unknown' }}</div>
+                            </td>
+                            <td>
+                                <div class="small">{{ member.email }}</div>
+                                {% if member.phone %}
+                                    <div class="small text-muted">{{ member.phone }}</div>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <span class="badge bg-info bg-opacity-10 text-info">{{ member.assimilation_stage or 'New Connection' }}</span>
+                            </td>
+                            <td style="min-width: 200px;">
+                                <div class="progress" style="height: 6px;">
+                                    <div class="progress-bar" role="progressbar" style="width: {{ member.milestone_completion_percent }}%;" aria-valuenow="{{ member.milestone_completion_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
+                                </div>
+                                <div class="small text-muted mt-1">{{ completed }} / {{ total }} milestones</div>
+                            </td>
+                            <td>
+                                {% if member.next_follow_up_date %}
+                                    <span class="small">{{ member.next_follow_up_date.strftime('%b %d, %Y') }}</span>
+                                    {% if member.follow_up_due %}
+                                        <span class="badge bg-warning text-dark ms-1">Due</span>
+                                    {% endif %}
+                                {% else %}
+                                    <span class="text-muted small">Not scheduled</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if member.last_interaction_at %}
+                                    <span class="small">{{ member.last_interaction_at.strftime('%b %d, %Y') }}</span>
+                                {% else %}
+                                    <span class="text-muted small">No interactions yet</span>
+                                {% endif %}
+                            </td>
+                            <td class="text-end">
+                                <a href="{{ url_for('admin.member_profile', member_id=member.id) }}" class="btn btn-sm btn-outline-primary">View</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                {% else %}
+                    <tr>
+                        <td colspan="7" class="text-center py-4 text-muted">No members found. Use the admin tools or import process to begin tracking people.</td>
+                    </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce household, member, and care interaction models to track demographics, milestones, and follow-up activity tied to portal users
- add member management dashboard pages for listing profiles, viewing details, and logging follow-ups while surfacing assimilation stats on the admin dashboard
- connect prayer submissions and sermon engagement to member care interactions and clean application setup configuration for task queues and dependencies

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask'; dependency installation via `pip install -e .` also failed because of editable build discovery issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1bf770048333ac8b6d3d3785679f