### PR TITLE
Add automation workflow system and admin management UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,31 +1,30 @@
+import logging
+import os
+from datetime import datetime
+
 from flask import Flask, render_template, request, g, session, redirect, url_for
-from flask_sqlalchemy import SQLAlchemy
+from flask_cors import CORS
 from flask_login import LoginManager
 from flask_mail import Mail
+from flask_sqlalchemy import SQLAlchemy
 from flask_wtf import CSRFProtect
-codex/explain-requested-code-functionality-dxdu2u
-from flask_cors import CORS
 from redis import Redis
 from rq import Queue
-from redis import Redis
-from rq import Queue
-import os
-main
-from datetime import datetime
-import logging
+
 from config import Config
+
 
 db = SQLAlchemy()
 login_manager = LoginManager()
 mail = Mail()
 csrf = CSRFProtect()
-codex/explain-requested-code-functionality-dxdu2u
 cors = CORS()
+
 redis_conn = Redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379/0"))
 task_queue = Queue(connection=redis_conn)
-main
 
-def create_app():
+
+def create_app() -> Flask:
     app = Flask(__name__)
     app.config.from_object(Config)
 
@@ -33,15 +32,15 @@ def create_app():
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger('covenant_connect')
     handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    ))
-    logger.addHandler(handler)
-codex/explain-requested-code-functionality-dxdu2u
+    handler.setFormatter(
+        logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    )
+    if not any(isinstance(existing, logging.StreamHandler) for existing in logger.handlers):
+        logger.addHandler(handler)
 
     if Config.SECRET_KEY == 'dev-secret-key':
         logger.warning('SECRET_KEY is not set. Using development key.')
-    
+
     # Configure database
     database_url = os.getenv('DATABASE_URL', 'sqlite:///app.db')
     if not database_url:
@@ -63,22 +62,22 @@ codex/explain-requested-code-functionality-dxdu2u
     app.config['MAIL_USERNAME'] = os.getenv('MAIL_USERNAME')
     app.config['MAIL_PASSWORD'] = os.getenv('MAIL_PASSWORD')
     app.config['MAIL_DEFAULT_SENDER'] = os.getenv('MAIL_DEFAULT_SENDER')
-main
+
+    if not app.config.get('CORS_ORIGINS'):
+        app.config['CORS_ORIGINS'] = ['*']
 
     # Initialize extensions
     db.init_app(app)
     login_manager.init_app(app)
     mail.init_app(app)
     csrf.init_app(app)
-codex/explain-requested-code-functionality-dxdu2u
     cors.init_app(app, resources={r"/*": {"origins": app.config['CORS_ORIGINS']}})
- main
     login_manager.login_view = 'auth.login'
-    app.task_queue = task_queue
 
-    # Initialize task queue lazily
-    redis_conn = Redis.from_url(app.config['REDIS_URL'])
-    app.task_queue = Queue(connection=redis_conn)
+    # Initialize task queue
+    redis_url = app.config.get('REDIS_URL') or os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+    redis_connection = Redis.from_url(redis_url)
+    app.task_queue = Queue(connection=redis_connection)
 
     # Register blueprints
     from routes.home import home_bp
@@ -90,12 +89,9 @@ codex/explain-requested-code-functionality-dxdu2u
     from routes.gallery import gallery_bp
     from routes.donations import donations_bp
     from routes.notifications import notifications_bp
- codex/find-current-location-in-codebase-aqxt07
-    from routes.solutions import solutions_bp
- codex/find-current-location-in-codebase-ntia0s
     from routes.solutions import solutions_bp
     from routes.internal import internal_bp
-     main
+
     app.register_blueprint(home_bp)
     app.register_blueprint(auth_bp)
     app.register_blueprint(admin_bp)
@@ -105,21 +101,17 @@ codex/explain-requested-code-functionality-dxdu2u
     app.register_blueprint(gallery_bp)
     app.register_blueprint(donations_bp)
     app.register_blueprint(notifications_bp)
- codex/find-current-location-in-codebase-aqxt07
-    app.register_blueprint(solutions_bp)
- codex/find-current-location-in-codebase-ntia0s
     app.register_blueprint(solutions_bp)
     app.register_blueprint(internal_bp)
-     main
-    # Context processors
+
     @app.context_processor
     def inject_year():
         return {'current_year': datetime.utcnow().year}
 
-    # Load user
     from models import User
+
     @login_manager.user_loader
-    def load_user(user_id):
+    def load_user(user_id: str):
         return db.session.get(User, int(user_id))
 
     return app

--- a/models.py
+++ b/models.py
@@ -88,3 +88,45 @@ class Settings(db.Model):
     contact_info = db.Column(db.JSON, default=dict)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class Automation(db.Model):
+    __tablename__ = 'automations'
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(150), nullable=False)
+    trigger = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.Text)
+    is_active = db.Column(db.Boolean, default=True)
+    default_channel = db.Column(db.String(50))
+    target_department = db.Column(db.String(120))
+    trigger_filters = db.Column(db.JSON, default=dict)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    steps = db.relationship(
+        'AutomationStep',
+        back_populates='automation',
+        cascade='all, delete-orphan',
+        order_by='AutomationStep.order',
+    )
+
+
+class AutomationStep(db.Model):
+    __tablename__ = 'automation_steps'
+
+    id = db.Column(db.Integer, primary_key=True)
+    automation_id = db.Column(
+        db.Integer, db.ForeignKey('automations.id'), nullable=False
+    )
+    title = db.Column(db.String(150))
+    action_type = db.Column(db.String(50), nullable=False)
+    channel = db.Column(db.String(50))
+    department = db.Column(db.String(120))
+    order = db.Column(db.Integer, default=0)
+    delay_minutes = db.Column(db.Integer, default=0)
+    config = db.Column(db.JSON, default=dict)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    automation = db.relationship('Automation', back_populates='steps')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ dependencies = [
     "redis>=5.2.0",
     "flask-wtf>=1.2.1",
     "rq>=1.16.2",
-codex/explain-requested-code-functionality-dxdu2u
     "flask-cors>=4.0.0",
     "python-dotenv>=1.0.1",
-main
 ]

--- a/routes/events.py
+++ b/routes/events.py
@@ -1,40 +1,37 @@
 from datetime import datetime
 
 from flask import Blueprint, current_app, flash, redirect, render_template, url_for
- codex/find-current-location-in-codebase-aqxt07
-from app import db
- codex/find-current-location-in-codebase-ntia0s
-from app import db
-     main
-from models import Event
 from sqlalchemy.exc import SQLAlchemyError
 
+from app import db
+from models import Event
+from tasks import trigger_automation
+
+
 events_bp = Blueprint('events', __name__)
+
 
 @events_bp.route('/events')
 def events():
     try:
         events_list = Event.query.order_by(Event.start_date).all()
         return render_template('events.html', events=events_list)
-    except SQLAlchemyError as e:
-        current_app.logger.error(f"Database error while fetching events: {str(e)}")
+    except SQLAlchemyError as exc:
+        current_app.logger.error(
+            "Database error while fetching events: %s", exc,
+        )
         flash('Unable to load events at this time. Please try again later.', 'danger')
         return render_template('events.html', events=[])
-    except Exception as e:
-        current_app.logger.error(f"Unexpected error in events route: {str(e)}")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        current_app.logger.error("Unexpected error in events route: %s", exc)
         flash('An unexpected error occurred. Please try again later.', 'danger')
         return render_template('events.html', events=[])
 
 
 @events_bp.route('/events/<int:event_id>')
-def event_detail(event_id):
+def event_detail(event_id: int):
     try:
- codex/find-current-location-in-codebase-aqxt07
         event = db.session.get(Event, event_id)
- codex/find-current-location-in-codebase-ntia0s
-        event = db.session.get(Event, event_id)
-        event = Event.query.get(event_id)
-        main
         if not event:
             flash('Event not found.', 'warning')
             return redirect(url_for('events.events'))
@@ -47,20 +44,25 @@ def event_detail(event_id):
             .all()
         )
 
+        trigger_automation('event_viewed', {'event_id': event.id})
+
         return render_template(
             'event_detail.html',
             event=event,
-            upcoming_events=upcoming_events
+            upcoming_events=upcoming_events,
         )
-    except SQLAlchemyError as e:
+    except SQLAlchemyError as exc:
         current_app.logger.error(
-            f"Database error while fetching event {event_id}: {str(e)}"
+            "Database error while fetching event %s: %s",
+            event_id,
+            exc,
         )
         flash('Unable to load the event at this time. Please try again later.', 'danger')
         return redirect(url_for('events.events'))
-    except Exception as e:
+    except Exception as exc:  # pragma: no cover - defensive logging
         current_app.logger.error(
-            f"Unexpected error in event_detail route: {str(e)}"
+            "Unexpected error in event_detail route: %s",
+            exc,
         )
         flash('An unexpected error occurred. Please try again later.', 'danger')
         return redirect(url_for('events.events'))

--- a/routes/prayers.py
+++ b/routes/prayers.py
@@ -1,16 +1,19 @@
 from flask import Blueprint, render_template, request, flash, redirect, url_for, current_app
-codex/explain-requested-code-functionality-dxdu2u
+
 from app import db
-from app import db, task_queue
-main
-from models import PrayerRequest, User
-from tasks import send_prayer_notification
+from models import PrayerRequest
+from tasks import send_prayer_notification, trigger_automation
 
 prayers_bp = Blueprint('prayers', __name__)
 
+
 @prayers_bp.route('/prayers', methods=['GET'])
 def prayers():
-    public_prayers = PrayerRequest.query.filter_by(is_public=True).order_by(PrayerRequest.created_at.desc()).all()
+    public_prayers = (
+        PrayerRequest.query.filter_by(is_public=True)
+        .order_by(PrayerRequest.created_at.desc())
+        .all()
+    )
     return render_template('prayers.html', prayers=public_prayers)
 
 
@@ -19,33 +22,42 @@ def submit_prayer():
     try:
         name = request.form.get('name')
         email = request.form.get('email')
-        prayer_request = request.form.get('request')
+        prayer_request_text = request.form.get('request')
         is_public = bool(request.form.get('is_public'))
 
-        if not all([name, email, prayer_request]):
+        if not all([name, email, prayer_request_text]):
             flash('Please fill all required fields', 'error')
             return redirect(url_for('prayers.prayers'))
 
         new_prayer = PrayerRequest(
             name=name,
             email=email,
-            request=prayer_request,
-            is_public=is_public
+            request=prayer_request_text,
+            is_public=is_public,
         )
-        
+
         db.session.add(new_prayer)
         db.session.commit()
-        
-        # Send email notification to admins
-codex/explain-requested-code-functionality-dxdu2u
-        current_app.task_queue.enqueue(send_prayer_notification, new_prayer.id)
-        task_queue.enqueue(send_prayer_notification, new_prayer.id)
-main
-        
+
+        triggered = trigger_automation(
+            'prayer_request_created',
+            {'prayer_request_id': new_prayer.id},
+        )
+
+        if triggered == 0:
+            queue = getattr(current_app, 'task_queue', None)
+            if queue:
+                queue.enqueue(send_prayer_notification, new_prayer.id)
+            else:
+                send_prayer_notification(new_prayer.id)
+
         flash('Prayer request submitted successfully', 'success')
         return redirect(url_for('prayers.prayers'))
-    except Exception as e:
-        current_app.logger.error(f"Error submitting prayer request: {str(e)}")
+    except Exception as exc:
+        current_app.logger.error(f"Error submitting prayer request: {exc}")
         db.session.rollback()
-        flash('An error occurred while submitting your prayer request. Please try again.', 'error')
+        flash(
+            'An error occurred while submitting your prayer request. Please try again.',
+            'error',
+        )
         return redirect(url_for('prayers.prayers'))

--- a/tasks.py
+++ b/tasks.py
@@ -1,9 +1,25 @@
+"""Utility functions for asynchronous tasks and workflow automations."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any, Dict, Iterable, List
+
+from flask import current_app, render_template_string
 from flask_mail import Message
-from models import PrayerRequest, User
+
+from models import (
+    Automation,
+    AutomationStep,
+    Event,
+    PrayerRequest,
+    Sermon,
+    User,
+)
+
 
 def send_prayer_notification(prayer_request_id: int) -> None:
-    from app import create_app, mail, db
-    from flask import current_app
+    from app import create_app, mail
 
     """Background task to send prayer notification emails to admins."""
     app = create_app()
@@ -15,7 +31,9 @@ def send_prayer_notification(prayer_request_id: int) -> None:
 
         admin_users = User.query.filter_by(is_admin=True).all()
         if not admin_users:
-            current_app.logger.warning("No admin users found to notify about prayer request")
+            current_app.logger.warning(
+                "No admin users found to notify about prayer request"
+            )
             return
 
         subject = "New Prayer Request Received"
@@ -28,9 +46,327 @@ Request: {prayer_request.request}
 Public: {'Yes' if prayer_request.is_public else 'No'}
 Submitted: {prayer_request.created_at.strftime('%B %d, %Y %I:%M %p')}
 """
-        msg = Message(subject=subject,
-                      recipients=[admin.email for admin in admin_users],
-                      body=body)
+        msg = Message(
+            subject=subject,
+            recipients=[admin.email for admin in admin_users],
+            body=body,
+        )
         mail.send(msg)
         current_app.logger.info(
-            f"Prayer request notification sent to {len(admin_users)} admin(s)")
+            "Prayer request notification sent to %s admin(s)",
+            len(admin_users),
+        )
+
+
+def trigger_automation(trigger: str, context: Dict[str, Any] | None = None) -> int:
+    """Schedule automations for a trigger and return number of matched workflows."""
+
+    context = context or {}
+    automation_ids = _collect_active_automation_ids(trigger)
+
+    if not automation_ids:
+        return 0
+
+    queue = _resolve_queue()
+    if queue:
+        queue.enqueue(run_automations_for_ids, automation_ids, context, trigger)
+    else:
+        run_automations_for_ids(automation_ids, context, trigger)
+
+    return len(automation_ids)
+
+
+def run_automations_for_ids(
+    automation_ids: Iterable[int],
+    context: Dict[str, Any] | None = None,
+    trigger: str | None = None,
+) -> None:
+    """Execute the automations identified by ``automation_ids``."""
+
+    from app import create_app
+
+    context = context or {}
+    automation_ids = list(automation_ids)
+    if not automation_ids:
+        return
+
+    app = create_app()
+
+    with app.app_context():
+        active_automations = (
+            Automation.query.filter(
+                Automation.id.in_(list(automation_ids)),
+                Automation.is_active.is_(True),
+            )
+            .order_by(Automation.id)
+            .all()
+        )
+
+        queue = getattr(app, "task_queue", None)
+
+        for automation in active_automations:
+            _schedule_automation_steps(automation, context, trigger, queue)
+
+
+def execute_automation_step(
+    step_id: int, context: Dict[str, Any] | None = None, trigger: str | None = None
+) -> None:
+    """Execute a single automation step."""
+
+    from app import create_app, mail
+
+    context = context or {}
+    app = create_app()
+
+    with app.app_context():
+        step = AutomationStep.query.get(step_id)
+        if not step or not step.automation or not step.automation.is_active:
+            return
+
+        expanded_context = _expand_context(context, trigger, step.automation)
+
+        try:
+            if step.action_type == "email":
+                _run_email_action(step, expanded_context, mail)
+            elif step.action_type == "sms":
+                _run_sms_action(step, expanded_context)
+            elif step.action_type == "assignment":
+                _run_assignment_action(step, expanded_context)
+            else:
+                current_app.logger.warning(
+                    "Unknown automation action type '%s' for step %s",
+                    step.action_type,
+                    step.id,
+                )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            current_app.logger.exception(
+                "Error executing automation step %s: %s", step.id, exc
+            )
+
+
+def _collect_active_automation_ids(trigger: str) -> List[int]:
+    """Return active automation IDs for a trigger, handling missing context."""
+
+    def _query_ids() -> List[int]:
+        return [
+            automation.id
+            for automation in Automation.query.filter_by(
+                trigger=trigger, is_active=True
+            ).all()
+        ]
+
+    try:
+        return _query_ids()
+    except RuntimeError:
+        from app import create_app
+
+        app = create_app()
+        with app.app_context():
+            return _query_ids()
+
+
+def _resolve_queue():
+    """Return the configured task queue if available."""
+
+    try:
+        queue = getattr(current_app, "task_queue", None)
+        if queue:
+            return queue
+    except RuntimeError:
+        return None
+
+    return None
+
+
+def _schedule_automation_steps(
+    automation: Automation,
+    context: Dict[str, Any],
+    trigger: str | None,
+    queue,
+) -> None:
+    """Schedule each step in an automation for execution."""
+
+    ordered_steps = sorted(
+        automation.steps,
+        key=lambda step: ((step.order or 0), step.id),
+    )
+
+    for step in ordered_steps:
+        step_context = dict(context)
+        if queue:
+            delay = max(step.delay_minutes or 0, 0)
+            if delay:
+                queue.enqueue_in(
+                    timedelta(minutes=delay),
+                    execute_automation_step,
+                    step.id,
+                    step_context,
+                    trigger,
+                )
+            else:
+                queue.enqueue(
+                    execute_automation_step,
+                    step.id,
+                    step_context,
+                    trigger,
+                )
+        else:
+            execute_automation_step(step.id, step_context, trigger)
+
+
+def _expand_context(
+    context: Dict[str, Any],
+    trigger: str | None,
+    automation: Automation,
+) -> Dict[str, Any]:
+    """Hydrate context with database objects referenced by identifiers."""
+
+    expanded = dict(context)
+    expanded.setdefault("trigger", trigger)
+    expanded.setdefault("automation_name", automation.name)
+    expanded.setdefault("automation_id", automation.id)
+
+    if "prayer_request_id" in expanded and "prayer_request" not in expanded:
+        prayer = PrayerRequest.query.get(expanded["prayer_request_id"])
+        if prayer:
+            expanded["prayer_request"] = prayer
+            expanded.setdefault("submitter_email", prayer.email)
+
+    if "event_id" in expanded and "event" not in expanded:
+        event = Event.query.get(expanded["event_id"])
+        if event:
+            expanded["event"] = event
+
+    if "sermon_id" in expanded and "sermon" not in expanded:
+        sermon = Sermon.query.get(expanded["sermon_id"])
+        if sermon:
+            expanded["sermon"] = sermon
+
+    if "user_id" in expanded and "user" not in expanded:
+        user = User.query.get(expanded["user_id"])
+        if user:
+            expanded["user"] = user
+
+    return expanded
+
+
+def _run_email_action(
+    step: AutomationStep,
+    context: Dict[str, Any],
+    mail,
+) -> None:
+    config = step.config or {}
+
+    recipients = _resolve_recipients(step, config, context)
+    if not recipients:
+        current_app.logger.info(
+            "Skipping automation email step %s because no recipients were resolved",
+            step.id,
+        )
+        return
+
+    render_context = dict(context)
+    render_context.update({"step": step, "automation": step.automation})
+
+    subject_template = config.get("subject") or step.title or step.automation.name
+    body_template = config.get("body") or ""
+
+    subject = render_template_string(subject_template, **render_context).strip()
+    body = render_template_string(body_template, **render_context)
+
+    message = Message(subject=subject, recipients=recipients, body=body)
+    mail.send(message)
+
+    current_app.logger.info(
+        "Automation email step %s sent to %s recipient(s)",
+        step.id,
+        len(recipients),
+    )
+
+
+def _run_sms_action(step: AutomationStep, context: Dict[str, Any]) -> None:
+    config = step.config or {}
+    recipients = _resolve_recipients(step, config, context)
+    message_template = config.get("message") or config.get("body") or ""
+
+    if not recipients:
+        current_app.logger.info(
+            "No SMS recipients resolved for automation step %s", step.id
+        )
+        return
+
+    render_context = dict(context)
+    render_context.update({"step": step, "automation": step.automation})
+    message = render_template_string(message_template, **render_context)
+
+    current_app.logger.info(
+        "SMS automation step %s would notify %s via channel '%s': %s",
+        step.id,
+        ", ".join(recipients),
+        step.channel or "sms",
+        message,
+    )
+
+
+def _run_assignment_action(step: AutomationStep, context: Dict[str, Any]) -> None:
+    config = step.config or {}
+    department = step.department or config.get("department")
+    assignee = config.get("assignee")
+    notes = config.get("notes") or config.get("body")
+
+    render_context = dict(context)
+    render_context.update({"step": step, "automation": step.automation})
+
+    formatted_notes = (
+        render_template_string(notes, **render_context) if notes else ""
+    )
+
+    current_app.logger.info(
+        "Automation step %s assigned to department '%s' (assignee: %s). %s",
+        step.id,
+        department or "unspecified",
+        assignee or "n/a",
+        formatted_notes,
+    )
+
+
+def _resolve_recipients(
+    step: AutomationStep,
+    config: Dict[str, Any],
+    context: Dict[str, Any],
+) -> List[str]:
+    """Resolve recipients from configuration and context."""
+
+    def _split(value: str | None) -> List[str]:
+        if not value:
+            return []
+        return [item.strip() for item in value.split(",") if item.strip()]
+
+    recipient_mode = (config.get("recipient_mode") or "custom").lower()
+    recipients: List[str] = []
+
+    if recipient_mode == "admins":
+        recipients = [
+            user.email
+            for user in User.query.filter_by(is_admin=True).all()
+            if user.email
+        ]
+    elif recipient_mode == "context":
+        key = config.get("context_key") or "submitter_email"
+        value = context.get(key)
+        if isinstance(value, str):
+            recipients = [value]
+        elif isinstance(value, (list, tuple, set)):
+            recipients = [item for item in value if isinstance(item, str)]
+    elif recipient_mode == "department":
+        recipients = _split(config.get("department_emails"))
+    else:  # custom
+        recipients = _split(config.get("recipients"))
+
+    if not recipients:
+        recipients = _split(config.get("fallback_recipients"))
+
+    if not recipients and step.department:
+        recipients = _split(config.get("department_emails"))
+
+    return recipients

--- a/templates/admin/automations/detail.html
+++ b/templates/admin/automations/detail.html
@@ -1,0 +1,205 @@
+{% extends "admin/base.html" %}
+
+{% block admin_content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <div>
+        <h1 class="mb-0">{{ automation.name }}</h1>
+        <p class="text-muted mb-0">Trigger: <span class="badge bg-secondary">{{ automation.trigger }}</span></p>
+    </div>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <a href="{{ url_for('admin.edit_automation', automation_id=automation.id) }}" class="btn btn-sm btn-outline-secondary">
+            <i class="bi bi-pencil"></i> Edit details
+        </a>
+    </div>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+{% endwith %}
+
+<div class="row">
+    <div class="col-lg-4">
+        <div class="card mb-4">
+            <div class="card-body">
+                <h5 class="card-title">Automation Overview</h5>
+                <dl class="row small mb-0">
+                    <dt class="col-5">Status</dt>
+                    <dd class="col-7">
+                        {% if automation.is_active %}
+                            <span class="badge bg-success">Active</span>
+                        {% else %}
+                            <span class="badge bg-secondary">Paused</span>
+                        {% endif %}
+                    </dd>
+                    <dt class="col-5">Department</dt>
+                    <dd class="col-7">{{ automation.target_department or '—' }}</dd>
+                    <dt class="col-5">Default channel</dt>
+                    <dd class="col-7">{{ automation.default_channel or '—' }}</dd>
+                    <dt class="col-5">Created</dt>
+                    <dd class="col-7">{{ automation.created_at.strftime('%b %d, %Y %H:%M') if automation.created_at else '—' }}</dd>
+                    <dt class="col-5">Updated</dt>
+                    <dd class="col-7">{{ automation.updated_at.strftime('%b %d, %Y %H:%M') if automation.updated_at else '—' }}</dd>
+                </dl>
+                {% if automation.description %}
+                    <hr>
+                    <p class="small mb-0">{{ automation.description }}</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-8">
+        {% if automation.steps %}
+            {% for step in automation.steps %}
+            <div class="card mb-4">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <div>
+                        <strong>Step {{ loop.index }}:</strong>
+                        {{ step.title or step.action_type|capitalize }}
+                    </div>
+                    <span class="badge bg-light text-dark">{{ step.action_type|capitalize }}</span>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="{{ url_for('admin.save_automation_step', automation_id=automation.id) }}" class="mb-2">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <input type="hidden" name="step_id" value="{{ step.id }}">
+
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label" for="title-{{ step.id }}">Step title</label>
+                                <input type="text" class="form-control" id="title-{{ step.id }}" name="title"
+                                       value="{{ step.title or '' }}"
+                                       placeholder="e.g. Notify Pastoral Team">
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label" for="action_type-{{ step.id }}">Action type</label>
+                                <select class="form-select" id="action_type-{{ step.id }}" name="action_type" required>
+                                    {% for value, label in action_types %}
+                                        <option value="{{ value }}" {% if step.action_type == value %}selected{% endif %}>{{ label }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label" for="channel-{{ step.id }}">Channel</label>
+                                <select class="form-select" id="channel-{{ step.id }}" name="channel">
+                                    <option value="">—</option>
+                                    {% for channel in channel_options %}
+                                        <option value="{{ channel }}" {% if step.channel == channel %}selected{% endif %}>{{ channel|capitalize }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label" for="department-{{ step.id }}">Department</label>
+                                <input type="text" class="form-control" id="department-{{ step.id }}" name="department"
+                                       value="{{ step.department or '' }}" placeholder="e.g. Communications">
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label" for="order-{{ step.id }}">Execution order</label>
+                                <input type="number" class="form-control" id="order-{{ step.id }}" name="order" min="1"
+                                       value="{{ step.order or loop.index }}">
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label" for="delay-{{ step.id }}">Delay (minutes)</label>
+                                <input type="number" class="form-control" id="delay-{{ step.id }}" name="delay_minutes" min="0"
+                                       value="{{ step.delay_minutes or 0 }}">
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label class="form-label" for="config-{{ step.id }}">Action configuration</label>
+                            <textarea class="form-control font-monospace" id="config-{{ step.id }}" name="config" rows="6">{{ step_configs[step.id] }}</textarea>
+                            <div class="form-text">Provide JSON data for this action (e.g. recipients, templates, notes).</div>
+                        </div>
+
+                        <div class="d-flex justify-content-between align-items-center">
+                            <button type="submit" class="btn btn-primary">Save Step</button>
+                        </div>
+                    </form>
+                    <form method="post" class="text-end" action="{{ url_for('admin.delete_automation_step', automation_id=automation.id, step_id=step.id) }}">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('Delete this step?');">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </form>
+                </div>
+            </div>
+            {% endfor %}
+        {% else %}
+            <div class="alert alert-info">No steps defined yet. Add your first action below.</div>
+        {% endif %}
+
+        <div class="card">
+            <div class="card-header">
+                <strong>Add New Step</strong>
+            </div>
+            <div class="card-body">
+                <form method="post" action="{{ url_for('admin.save_automation_step', automation_id=automation.id) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label" for="new-title">Step title</label>
+                            <input type="text" class="form-control" id="new-title" name="title" placeholder="Describe the action">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label" for="new-action">Action type</label>
+                            <select class="form-select" id="new-action" name="action_type" required>
+                                {% for value, label in action_types %}
+                                    <option value="{{ value }}">{{ label }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label" for="new-channel">Channel</label>
+                            <select class="form-select" id="new-channel" name="channel">
+                                <option value="">—</option>
+                                {% for channel in channel_options %}
+                                    <option value="{{ channel }}">{{ channel|capitalize }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label" for="new-department">Department</label>
+                            <input type="text" class="form-control" id="new-department" name="department" placeholder="Team responsible">
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label" for="new-order">Execution order</label>
+                            <input type="number" class="form-control" id="new-order" name="order" min="1" value="{{ automation.steps|length + 1 }}">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label" for="new-delay">Delay (minutes)</label>
+                            <input type="number" class="form-control" id="new-delay" name="delay_minutes" min="0" value="0">
+                        </div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="new-config">Action configuration</label>
+                        <textarea class="form-control font-monospace" id="new-config" name="config" rows="6">{{ default_step_config }}</textarea>
+                        <div class="form-text">Use JSON to describe who should receive the message or assignment.</div>
+                    </div>
+
+                    <button type="submit" class="btn btn-success">Add Step</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/automations/form.html
+++ b/templates/admin/automations/form.html
@@ -1,0 +1,112 @@
+{% extends "admin/base.html" %}
+
+{% block admin_content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1>{{ 'Edit Automation' if automation.id else 'Create Automation' }}</h1>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+{% endwith %}
+
+<div class="row">
+    <div class="col-lg-8">
+        <div class="card mb-4">
+            <div class="card-body">
+                <form method="post" novalidate>
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+                    <div class="mb-3">
+                        <label for="name" class="form-label">Automation Name</label>
+                        <input type="text" class="form-control" id="name" name="name" required
+                               value="{{ request.form.name or automation.name }}">
+                        <div class="form-text">Give this workflow a descriptive name so other admins can identify it.</div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="trigger" class="form-label">Trigger</label>
+                            <select class="form-select" id="trigger" name="trigger" required>
+                                {% for value, label in trigger_choices %}
+                                    <option value="{{ value }}"
+                                            {% if (request.form.trigger or automation.trigger) == value %}selected{% endif %}>
+                                        {{ label }}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="default_channel" class="form-label">Default Channel</label>
+                            <select class="form-select" id="default_channel" name="default_channel">
+                                <option value="">—</option>
+                                {% for channel in channel_options %}
+                                    <option value="{{ channel }}"
+                                            {% if (request.form.default_channel or automation.default_channel) == channel %}selected{% endif %}>
+                                        {{ channel|capitalize }}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="target_department" class="form-label">Target Department</label>
+                            <input type="text" class="form-control" id="target_department" name="target_department"
+                                   placeholder="e.g. Pastoral Care"
+                                   value="{{ request.form.target_department or automation.target_department }}">
+                        </div>
+                        <div class="col-md-6 mb-3 d-flex align-items-center">
+                            <div class="form-check mt-4">
+                                <input class="form-check-input" type="checkbox" id="is_active" name="is_active"
+                                       {% if (request.form and request.form.get('is_active')) or (not request.form and automation.is_active) %}checked{% endif %}>
+                                <label class="form-check-label" for="is_active">Automation is active</label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="description" class="form-label">Description</label>
+                        <textarea class="form-control" id="description" name="description" rows="3"
+                                  placeholder="Explain what this workflow is responsible for.">{{ request.form.description or automation.description }}</textarea>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="trigger_filters" class="form-label">Trigger Filters (optional)</label>
+                        <textarea class="form-control font-monospace" id="trigger_filters" name="trigger_filters"
+                                  rows="6" placeholder="{}">{{ trigger_filters }}</textarea>
+                        <div class="form-text">Provide additional JSON filters to limit when this automation runs (for example, {"event_type": "baptism"}).</div>
+                    </div>
+
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">Save Automation</button>
+                        <a href="{{ url_for('admin.automations') }}" class="btn btn-secondary">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-4">
+        <div class="card">
+            <div class="card-header">
+                <h5 class="mb-0">Automation Tips</h5>
+            </div>
+            <div class="card-body">
+                <p class="small text-muted">Use automations to notify departments when key ministry events occur. Each automation can contain one or more steps that send messages or assign follow up work.</p>
+                <ul class="small">
+                    <li>Triggers determine when the automation runs.</li>
+                    <li>Steps can send emails, log SMS actions, or assign a department.</li>
+                    <li>Use the trigger filters to narrow the events that should run this workflow.</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/automations/index.html
+++ b/templates/admin/automations/index.html
@@ -1,0 +1,90 @@
+{% extends "admin/base.html" %}
+
+{% block admin_content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1>Workflow Automations</h1>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <a href="{{ url_for('admin.create_automation') }}" class="btn btn-sm btn-outline-primary">
+            <i class="bi bi-plus-lg"></i> New Automation
+        </a>
+    </div>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+{% endwith %}
+
+<div class="card">
+    <div class="card-body">
+        {% if automations %}
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col">Name</th>
+                            <th scope="col">Trigger</th>
+                            <th scope="col">Steps</th>
+                            <th scope="col">Department</th>
+                            <th scope="col">Status</th>
+                            <th scope="col" class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for automation in automations %}
+                        <tr>
+                            <td>{{ automation.name }}</td>
+                            <td>
+                                <span class="badge bg-secondary">{{ automation.trigger }}</span>
+                            </td>
+                            <td>{{ automation.steps|length }}</td>
+                            <td>{{ automation.target_department or '—' }}</td>
+                            <td>
+                                {% if automation.is_active %}
+                                    <span class="badge bg-success">Active</span>
+                                {% else %}
+                                    <span class="badge bg-secondary">Paused</span>
+                                {% endif %}
+                            </td>
+                            <td class="text-end">
+                                <div class="btn-group" role="group">
+                                    <a href="{{ url_for('admin.automation_detail', automation_id=automation.id) }}" class="btn btn-sm btn-outline-primary">
+                                        <i class="bi bi-diagram-3"></i> View
+                                    </a>
+                                    <a href="{{ url_for('admin.edit_automation', automation_id=automation.id) }}" class="btn btn-sm btn-outline-secondary">
+                                        <i class="bi bi-pencil"></i> Edit
+                                    </a>
+                                    <form method="post" action="{{ url_for('admin.delete_automation', automation_id=automation.id) }}" class="d-inline">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this automation?');">
+                                            <i class="bi bi-trash"></i>
+                                        </button>
+                                    </form>
+                                </div>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <div class="text-center py-5">
+                <div class="mb-3">
+                    <i class="bi bi-diagram-3 display-5 text-muted"></i>
+                </div>
+                <h4 class="text-muted">No automations configured yet</h4>
+                <p class="text-muted">Create your first automation to automatically notify teams and assign follow-up tasks.</p>
+                <a href="{{ url_for('admin.create_automation') }}" class="btn btn-primary">
+                    <i class="bi bi-plus-lg"></i> Create Automation
+                </a>
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -8,21 +8,28 @@
             <div class="sidebar-sticky">
                 <ul class="nav flex-column">
                     <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.dashboard' %}active{% endif %}" 
+                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.dashboard' %}active{% endif %}"
                            href="{{ url_for('admin.dashboard') }}">
                             <i class="bi bi-speedometer2"></i>
                             <span>Dashboard</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.users' %}active{% endif %}" 
+                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.users' %}active{% endif %}"
                            href="{{ url_for('admin.users') }}">
                             <i class="bi bi-people"></i>
                             <span>Users</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.events' %}active{% endif %}" 
+                        <a class="nav-link d-flex align-items-center {% if request.endpoint and request.endpoint.startswith('admin.automation') %}active{% endif %}"
+                           href="{{ url_for('admin.automations') }}">
+                            <i class="bi bi-diagram-3"></i>
+                            <span>Automations</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link d-flex align-items-center {% if request.endpoint == 'admin.events' %}active{% endif %}"
                            href="{{ url_for('admin.events') }}">
                             <i class="bi bi-calendar-event"></i>
                             <span>Events</span>


### PR DESCRIPTION
## Summary
- introduce Automation and AutomationStep models plus queue-driven task helpers for executing workflow actions
- add admin screens and navigation for creating, editing, and scheduling automation steps tied to departments or channels
- hook automation triggers into prayer submissions, event and sermon views/creation, and refresh application bootstrap configuration

## Testing
- `pytest` *(fails: existing routes/solutions.py has indentation errors outside the changes)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1c0a80048333bf49a2a469db587a