### PR TITLE
Implement provider API initialization for donations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,5 @@ dependencies = [
     "rq>=1.16.2",
     "flask-cors>=4.0.0",
     "python-dotenv>=1.0.1",
+    "requests>=2.32.3",
 ]

--- a/routes/donations.py
+++ b/routes/donations.py
@@ -7,6 +7,9 @@ import uuid
 import json
 from datetime import datetime
 
+import requests
+from requests.exceptions import RequestException, Timeout
+
 donations_bp = Blueprint('donations', __name__)
 
 @donations_bp.route('/donate', methods=['GET'])
@@ -70,52 +73,155 @@ def process_donation():
         db.session.add(donation)
         db.session.commit()
 
+        def _update_donation(*, status=None, transaction_id=None, error_message=None, provider_info=None):
+            info = dict(donation.payment_info or {})
+            if provider_info:
+                info.update(provider_info)
+                donation.payment_info = info
+            if transaction_id:
+                donation.transaction_id = str(transaction_id)
+            if status:
+                donation.status = status
+            if error_message is not None:
+                donation.error_message = error_message
+            donation.updated_at = datetime.utcnow()
+            db.session.add(donation)
+            db.session.commit()
+
+        def _handle_failure(provider_name, user_message, log_message, provider_info=None):
+            try:
+                _update_donation(
+                    status='failed',
+                    error_message=log_message,
+                    provider_info=provider_info,
+                )
+            except Exception as db_error:
+                db.session.rollback()
+                current_app.logger.error(
+                    'Error saving %s failure state: %s', provider_name, db_error
+                )
+            current_app.logger.error(
+                '%s payment initialization failed: %s', provider_name, log_message
+            )
+            flash(user_message, 'danger')
+            return redirect(url_for('donations.donate'))
+
         # Initialize payment based on the selected method
         if payment_method == 'paystack' and currency == 'NGN':
             try:
-                # Initialize Paystack payment
                 secret_key = current_app.config.get('PAYSTACK_SECRET_KEY')
                 if not secret_key:
-                    flash('Payment processing is temporarily unavailable.', 'danger')
-                    current_app.logger.error("Paystack secret key not configured")
-                    return redirect(url_for('donations.donate'))
+                    return _handle_failure(
+                        'Paystack',
+                        'Payment processing is temporarily unavailable.',
+                        'Paystack secret key not configured.',
+                    )
 
                 headers = {
-                    'Authorization': f"Bearer {secret_key}",
-                    'Content-Type': 'application/json'
+                    'Authorization': f'Bearer {secret_key}',
+                    'Content-Type': 'application/json',
                 }
-                
+
                 payload = {
-                    'amount': int((amount * 100).to_integral_value()),  # Paystack expects amount in kobo
+                    'amount': int((amount * 100).to_integral_value()),
                     'currency': 'NGN',
                     'email': email,
                     'reference': reference,
-                    'callback_url': url_for('donations.payment_callback', _external=True)
+                    'callback_url': url_for('donations.payment_callback', _external=True),
                 }
 
-                # TODO: Make API call to Paystack to initialize payment
-                # For now, we'll simulate success
-                flash('Payment initialization successful!', 'success')
-                return redirect(url_for('donations.donate'))
+                try:
+                    response = requests.post(
+                        'https://api.paystack.co/transaction/initialize',
+                        headers=headers,
+                        json=payload,
+                        timeout=10,
+                    )
+                except Timeout:
+                    return _handle_failure(
+                        'Paystack',
+                        'Paystack payment timed out. Please try again later.',
+                        'Request to Paystack initialize endpoint timed out.',
+                    )
+                except RequestException as exc:
+                    return _handle_failure(
+                        'Paystack',
+                        'Unable to initialize Paystack payment. Please try again later.',
+                        f'Request to Paystack failed: {exc}',
+                    )
+
+                if response.status_code != 200:
+                    body = (getattr(response, 'text', '') or '')[:500]
+                    return _handle_failure(
+                        'Paystack',
+                        'Paystack payment initialization failed. Please try again later.',
+                        f'Non-200 response ({response.status_code}) from Paystack initialize endpoint: {body}',
+                        provider_info={'paystack_error': body},
+                    )
+
+                try:
+                    response_data = response.json()
+                except ValueError:
+                    return _handle_failure(
+                        'Paystack',
+                        'Paystack payment initialization failed. Please try again later.',
+                        'Invalid JSON response from Paystack initialize endpoint.',
+                    )
+
+                data = response_data.get('data') or {}
+                authorization_url = data.get('authorization_url') or response_data.get('authorization_url')
+                if not authorization_url:
+                    return _handle_failure(
+                        'Paystack',
+                        'Paystack payment initialization failed. Please try again later.',
+                        'Missing authorization URL in Paystack response.',
+                        provider_info={'provider_response': data},
+                    )
+
+                transaction_id = data.get('reference') or data.get('id') or response_data.get('reference')
+                provider_info = {
+                    'authorization_url': authorization_url,
+                    'provider_response': data,
+                }
+
+                try:
+                    _update_donation(
+                        transaction_id=transaction_id,
+                        provider_info=provider_info,
+                    )
+                except Exception as db_error:
+                    db.session.rollback()
+                    current_app.logger.error('Error saving Paystack response: %s', db_error)
+                    flash('Payment initialization failed. Please try again later.', 'danger')
+                    return redirect(url_for('donations.donate'))
+
+                return redirect(authorization_url)
 
             except Exception as e:
-                current_app.logger.error(f"Paystack payment initialization error: {str(e)}")
-                flash('Payment initialization failed. Please try again later.', 'danger')
-                return redirect(url_for('donations.donate'))
+                current_app.logger.exception("Paystack payment initialization error: %s", e)
+                db.session.rollback()
+                return _handle_failure(
+                    'Paystack',
+                    'Payment initialization failed. Please try again later.',
+                    f'Unexpected Paystack initialization error: {e}',
+                    provider_info={'paystack_exception': str(e)},
+                )
 
         elif payment_method == 'fincra':
             try:
                 secret_key = current_app.config.get('FINCRA_SECRET_KEY')
                 if not secret_key:
-                    flash('Payment processing is temporarily unavailable.', 'danger')
-                    current_app.logger.error("Fincra secret key not configured")
-                    return redirect(url_for('donations.donate'))
+                    return _handle_failure(
+                        'Fincra',
+                        'Payment processing is temporarily unavailable.',
+                        'Fincra secret key not configured.',
+                    )
 
                 headers = {
                     'api-key': secret_key,
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
                 }
-                
+
                 payload = {
                     'amount': str(amount),
                     'currency': currency,
@@ -124,58 +230,313 @@ def process_donation():
                     'customer': {
                         'firstName': payment_info['first_name'],
                         'lastName': payment_info['last_name'],
-                        'email': email
+                        'email': email,
                     },
                     'redirectUrl': url_for('donations.payment_callback', _external=True),
-                    'paymentType': 'card'
+                    'paymentType': 'card',
                 }
 
-                # TODO: Make API call to Fincra to initialize payment
-                # For now, we'll simulate success
-                flash('Payment initialization successful!', 'success')
-                return redirect(url_for('donations.donate'))
+                try:
+                    response = requests.post(
+                        'https://api.fincra.com/checkout/payments',
+                        headers=headers,
+                        json=payload,
+                        timeout=10,
+                    )
+                except Timeout:
+                    return _handle_failure(
+                        'Fincra',
+                        'Fincra payment timed out. Please try again later.',
+                        'Request to Fincra initialize endpoint timed out.',
+                    )
+                except RequestException as exc:
+                    return _handle_failure(
+                        'Fincra',
+                        'Unable to initialize Fincra payment. Please try again later.',
+                        f'Request to Fincra failed: {exc}',
+                    )
+
+                if response.status_code != 200:
+                    body = (getattr(response, 'text', '') or '')[:500]
+                    return _handle_failure(
+                        'Fincra',
+                        'Fincra payment initialization failed. Please try again later.',
+                        f'Non-200 response ({response.status_code}) from Fincra initialize endpoint: {body}',
+                        provider_info={'fincra_error': body},
+                    )
+
+                try:
+                    response_data = response.json()
+                except ValueError:
+                    return _handle_failure(
+                        'Fincra',
+                        'Fincra payment initialization failed. Please try again later.',
+                        'Invalid JSON response from Fincra initialize endpoint.',
+                    )
+
+                data = response_data.get('data') or {}
+                authorization_url = (
+                    data.get('checkoutUrl')
+                    or data.get('checkout_url')
+                    or data.get('paymentLink')
+                    or data.get('link')
+                )
+                if not authorization_url:
+                    return _handle_failure(
+                        'Fincra',
+                        'Fincra payment initialization failed. Please try again later.',
+                        'Missing checkout URL in Fincra response.',
+                        provider_info={'provider_response': data},
+                    )
+
+                transaction_id = (
+                    data.get('transactionReference')
+                    or data.get('reference')
+                    or data.get('id')
+                )
+                provider_info = {
+                    'authorization_url': authorization_url,
+                    'provider_response': data,
+                }
+
+                try:
+                    _update_donation(
+                        transaction_id=transaction_id,
+                        provider_info=provider_info,
+                    )
+                except Exception as db_error:
+                    db.session.rollback()
+                    current_app.logger.error('Error saving Fincra response: %s', db_error)
+                    flash('Payment initialization failed. Please try again later.', 'danger')
+                    return redirect(url_for('donations.donate'))
+
+                return redirect(authorization_url)
 
             except Exception as e:
-                current_app.logger.error(f"Fincra payment initialization error: {str(e)}")
-                flash('Payment initialization failed. Please try again later.', 'danger')
-                return redirect(url_for('donations.donate'))
+                current_app.logger.exception("Fincra payment initialization error: %s", e)
+                db.session.rollback()
+                return _handle_failure(
+                    'Fincra',
+                    'Payment initialization failed. Please try again later.',
+                    f'Unexpected Fincra initialization error: {e}',
+                    provider_info={'fincra_exception': str(e)},
+                )
+
         elif payment_method == 'stripe':
             try:
                 secret_key = current_app.config.get('STRIPE_SECRET_KEY')
                 if not secret_key:
-                    flash('Payment processing is temporarily unavailable.', 'danger')
-                    current_app.logger.error("Stripe secret key not configured")
+                    return _handle_failure(
+                        'Stripe',
+                        'Payment processing is temporarily unavailable.',
+                        'Stripe secret key not configured.',
+                    )
+
+                headers = {
+                    'Authorization': f'Bearer {secret_key}',
+                }
+
+                payload = {
+                    'mode': 'payment',
+                    'success_url': url_for(
+                        'donations.payment_callback', _external=True
+                    )
+                    + f'?status=successful&reference={reference}',
+                    'cancel_url': url_for('donations.donate', _external=True),
+                    'line_items[0][price_data][currency]': currency.lower(),
+                    'line_items[0][price_data][product_data][name]': 'Donation',
+                    'line_items[0][price_data][unit_amount]': int(
+                        (amount * 100).to_integral_value()
+                    ),
+                    'line_items[0][quantity]': 1,
+                    'customer_email': email,
+                }
+
+                try:
+                    response = requests.post(
+                        'https://api.stripe.com/v1/checkout/sessions',
+                        headers=headers,
+                        data=payload,
+                        timeout=10,
+                    )
+                except Timeout:
+                    return _handle_failure(
+                        'Stripe',
+                        'Stripe payment timed out. Please try again later.',
+                        'Request to Stripe initialize endpoint timed out.',
+                    )
+                except RequestException as exc:
+                    return _handle_failure(
+                        'Stripe',
+                        'Unable to initialize Stripe payment. Please try again later.',
+                        f'Request to Stripe failed: {exc}',
+                    )
+
+                if response.status_code != 200:
+                    body = (getattr(response, 'text', '') or '')[:500]
+                    return _handle_failure(
+                        'Stripe',
+                        'Stripe payment initialization failed. Please try again later.',
+                        f'Non-200 response ({response.status_code}) from Stripe initialize endpoint: {body}',
+                        provider_info={'stripe_error': body},
+                    )
+
+                try:
+                    response_data = response.json()
+                except ValueError:
+                    return _handle_failure(
+                        'Stripe',
+                        'Stripe payment initialization failed. Please try again later.',
+                        'Invalid JSON response from Stripe initialize endpoint.',
+                    )
+
+                authorization_url = response_data.get('url')
+                if not authorization_url:
+                    return _handle_failure(
+                        'Stripe',
+                        'Stripe payment initialization failed. Please try again later.',
+                        'Missing checkout URL in Stripe response.',
+                        provider_info={'provider_response': response_data},
+                    )
+
+                transaction_id = response_data.get('id')
+                provider_info = {
+                    'authorization_url': authorization_url,
+                    'provider_response': response_data,
+                }
+
+                try:
+                    _update_donation(
+                        transaction_id=transaction_id,
+                        provider_info=provider_info,
+                    )
+                except Exception as db_error:
+                    db.session.rollback()
+                    current_app.logger.error('Error saving Stripe response: %s', db_error)
+                    flash('Payment initialization failed. Please try again later.', 'danger')
                     return redirect(url_for('donations.donate'))
 
-                # TODO: Make API call to Stripe to initialize payment
-                flash('Payment initialization successful!', 'success')
-                return redirect(url_for('donations.donate'))
+                return redirect(authorization_url)
 
             except Exception as e:
-                current_app.logger.error(f"Stripe payment initialization error: {str(e)}")
-                flash('Payment initialization failed. Please try again later.', 'danger')
-                return redirect(url_for('donations.donate'))
+                current_app.logger.exception("Stripe payment initialization error: %s", e)
+                db.session.rollback()
+                return _handle_failure(
+                    'Stripe',
+                    'Payment initialization failed. Please try again later.',
+                    f'Unexpected Stripe initialization error: {e}',
+                    provider_info={'stripe_exception': str(e)},
+                )
 
         elif payment_method == 'flutterwave':
             try:
                 secret_key = current_app.config.get('FLUTTERWAVE_SECRET_KEY')
                 if not secret_key:
-                    flash('Payment processing is temporarily unavailable.', 'danger')
-                    current_app.logger.error("Flutterwave secret key not configured")
+                    return _handle_failure(
+                        'Flutterwave',
+                        'Payment processing is temporarily unavailable.',
+                        'Flutterwave secret key not configured.',
+                    )
+
+                headers = {
+                    'Authorization': f'Bearer {secret_key}',
+                    'Content-Type': 'application/json',
+                }
+
+                payload = {
+                    'tx_ref': reference,
+                    'amount': str(amount),
+                    'currency': currency,
+                    'redirect_url': url_for('donations.payment_callback', _external=True),
+                    'customer': {
+                        'email': email,
+                    },
+                    'payment_options': 'card',
+                }
+
+                try:
+                    response = requests.post(
+                        'https://api.flutterwave.com/v3/payments',
+                        headers=headers,
+                        json=payload,
+                        timeout=10,
+                    )
+                except Timeout:
+                    return _handle_failure(
+                        'Flutterwave',
+                        'Flutterwave payment timed out. Please try again later.',
+                        'Request to Flutterwave initialize endpoint timed out.',
+                    )
+                except RequestException as exc:
+                    return _handle_failure(
+                        'Flutterwave',
+                        'Unable to initialize Flutterwave payment. Please try again later.',
+                        f'Request to Flutterwave failed: {exc}',
+                    )
+
+                if response.status_code != 200:
+                    body = (getattr(response, 'text', '') or '')[:500]
+                    return _handle_failure(
+                        'Flutterwave',
+                        'Flutterwave payment initialization failed. Please try again later.',
+                        f'Non-200 response ({response.status_code}) from Flutterwave initialize endpoint: {body}',
+                        provider_info={'flutterwave_error': body},
+                    )
+
+                try:
+                    response_data = response.json()
+                except ValueError:
+                    return _handle_failure(
+                        'Flutterwave',
+                        'Flutterwave payment initialization failed. Please try again later.',
+                        'Invalid JSON response from Flutterwave initialize endpoint.',
+                    )
+
+                data = response_data.get('data') or {}
+                authorization_url = data.get('link') or data.get('url')
+                if not authorization_url:
+                    return _handle_failure(
+                        'Flutterwave',
+                        'Flutterwave payment initialization failed. Please try again later.',
+                        'Missing checkout URL in Flutterwave response.',
+                        provider_info={'provider_response': data},
+                    )
+
+                transaction_id = data.get('id') or data.get('flw_ref') or data.get('tx_ref')
+                provider_info = {
+                    'authorization_url': authorization_url,
+                    'provider_response': data,
+                }
+
+                try:
+                    _update_donation(
+                        transaction_id=transaction_id,
+                        provider_info=provider_info,
+                    )
+                except Exception as db_error:
+                    db.session.rollback()
+                    current_app.logger.error('Error saving Flutterwave response: %s', db_error)
+                    flash('Payment initialization failed. Please try again later.', 'danger')
                     return redirect(url_for('donations.donate'))
 
-                # TODO: Make API call to Flutterwave to initialize payment
-                flash('Payment initialization successful!', 'success')
-                return redirect(url_for('donations.donate'))
+                return redirect(authorization_url)
 
             except Exception as e:
-                current_app.logger.error(f"Flutterwave payment initialization error: {str(e)}")
-                flash('Payment initialization failed. Please try again later.', 'danger')
-                return redirect(url_for('donations.donate'))
+                current_app.logger.exception("Flutterwave payment initialization error: %s", e)
+                db.session.rollback()
+                return _handle_failure(
+                    'Flutterwave',
+                    'Payment initialization failed. Please try again later.',
+                    f'Unexpected Flutterwave initialization error: {e}',
+                    provider_info={'flutterwave_exception': str(e)},
+                )
 
         else:
-            flash('Invalid payment method or currency combination.', 'danger')
-            return redirect(url_for('donations.donate'))
+            return _handle_failure(
+                'Donation',
+                'Invalid payment method or currency combination.',
+                f'Unsupported payment method "{payment_method}" with currency "{currency}".',
+            )
 
     except ValueError as e:
         flash(str(e), 'danger')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,15 @@ from app import create_app, db
 @pytest.fixture
 def app():
     app = create_app()
-    app.config.update({'TESTING': True})
+    app.config.update(
+        {
+            'TESTING': True,
+            'PAYSTACK_SECRET_KEY': 'test-paystack',
+            'FINCRA_SECRET_KEY': 'test-fincra',
+            'STRIPE_SECRET_KEY': 'test-stripe',
+            'FLUTTERWAVE_SECRET_KEY': 'test-flutterwave',
+        }
+    )
     with app.app_context():
         db.create_all()
         yield app

--- a/tests/test_donation.py
+++ b/tests/test_donation.py
@@ -1,5 +1,9 @@
+import json
 from decimal import Decimal
 import re
+
+from requests.exceptions import RequestException, Timeout
+
 from models import Donation
 
 
@@ -9,57 +13,342 @@ def get_token(client, path):
     return token
 
 
+class DummyResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        if isinstance(payload, dict):
+            self.text = json.dumps(payload)
+        else:
+            self.text = '' if payload is None else str(payload)
+
+    def json(self):
+        if isinstance(self._payload, dict):
+            return self._payload
+        raise ValueError('No JSON payload configured')
+
+
 def test_donation_rejects_invalid_amount(client):
     token = get_token(client, '/donate')
-    resp = client.post('/donate/process', data={
-        'csrf_token': token,
-        'email': 'test@example.com',
-        'amount': 'abc',
-        'payment_method': 'paystack'
-    }, follow_redirects=True)
+    resp = client.post(
+        '/donate/process',
+        data={
+            'csrf_token': token,
+            'email': 'test@example.com',
+            'amount': 'abc',
+            'payment_method': 'paystack',
+        },
+        follow_redirects=True,
+    )
     assert b'valid donation amount' in resp.data.lower()
 
 
-def test_donation_stores_decimal(client, app):
+def test_paystack_success_redirects_to_authorization_url(monkeypatch, client, app):
     token = get_token(client, '/donate')
-    resp = client.post('/donate/process', data={
-        'csrf_token': token,
-        'email': 'user@example.com',
-        'amount': '10.50',
-        'payment_method': 'paystack',
-        'currency': 'NGN'
-    }, follow_redirects=True)
+    captured = {}
+
+    def mock_post(url, headers=None, json=None, data=None, timeout=None):
+        captured['url'] = url
+        captured['headers'] = headers
+        captured['json'] = json
+        captured['data'] = data
+        captured['timeout'] = timeout
+        return DummyResponse(
+            200,
+            {
+                'data': {
+                    'authorization_url': 'https://paystack.test/redirect',
+                    'reference': 'ref-123',
+                }
+            },
+        )
+
+    monkeypatch.setattr('routes.donations.requests.post', mock_post)
+
+    resp = client.post(
+        '/donate/process',
+        data={
+            'csrf_token': token,
+            'email': 'paystack-success@example.com',
+            'amount': '50.00',
+            'currency': 'NGN',
+            'payment_method': 'paystack',
+        },
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == 'https://paystack.test/redirect'
+    assert captured['url'].endswith('/transaction/initialize')
+    assert captured['headers']['Authorization'] == 'Bearer test-paystack'
+    assert captured['json']['amount'] == 5000
+    assert captured['timeout'] == 10
+
     with app.app_context():
-        donation = Donation.query.filter_by(email='user@example.com').first()
+        donation = Donation.query.filter_by(email='paystack-success@example.com').first()
         assert donation is not None
-        assert donation.amount == Decimal('10.50')
+        assert donation.amount == Decimal('50.00')
+        assert donation.transaction_id == 'ref-123'
+        assert donation.payment_info['authorization_url'] == 'https://paystack.test/redirect'
+        assert donation.payment_info['provider_response']['reference'] == 'ref-123'
+        assert donation.status == 'pending'
 
 
-def test_donation_accepts_stripe(client, app):
+def test_paystack_failure_marks_donation_failed(monkeypatch, client, app):
     token = get_token(client, '/donate')
-    client.post('/donate/process', data={
-        'csrf_token': token,
-        'email': 'stripe@example.com',
-        'amount': '5.00',
-        'payment_method': 'stripe',
-        'currency': 'USD'
-    }, follow_redirects=True)
+
+    def mock_post(url, headers=None, json=None, data=None, timeout=None):
+        return DummyResponse(400, {'status': False, 'message': 'Invalid data'})
+
+    monkeypatch.setattr('routes.donations.requests.post', mock_post)
+
+    resp = client.post(
+        '/donate/process',
+        data={
+            'csrf_token': token,
+            'email': 'paystack-failure@example.com',
+            'amount': '20.00',
+            'currency': 'NGN',
+            'payment_method': 'paystack',
+        },
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == '/donate'
+
     with app.app_context():
-        donation = Donation.query.filter_by(email='stripe@example.com').first()
+        donation = Donation.query.filter_by(email='paystack-failure@example.com').first()
         assert donation is not None
-        assert donation.payment_method == 'stripe'
+        assert donation.status == 'failed'
+        assert 'Non-200 response (400)' in donation.error_message
+        assert donation.transaction_id is None
+        assert 'paystack_error' in donation.payment_info
 
 
-def test_donation_accepts_flutterwave(client, app):
+def test_fincra_success_redirects_to_checkout(monkeypatch, client, app):
     token = get_token(client, '/donate')
-    client.post('/donate/process', data={
-        'csrf_token': token,
-        'email': 'flutter@example.com',
-        'amount': '7.00',
-        'payment_method': 'flutterwave',
-        'currency': 'USD'
-    }, follow_redirects=True)
+    captured = {}
+
+    def mock_post(url, headers=None, json=None, data=None, timeout=None):
+        captured['url'] = url
+        captured['headers'] = headers
+        captured['json'] = json
+        captured['timeout'] = timeout
+        return DummyResponse(
+            200,
+            {
+                'data': {
+                    'checkoutUrl': 'https://fincra.test/checkout',
+                    'transactionReference': 'txn-789',
+                }
+            },
+        )
+
+    monkeypatch.setattr('routes.donations.requests.post', mock_post)
+
+    resp = client.post(
+        '/donate/process',
+        data={
+            'csrf_token': token,
+            'email': 'fincra-success@example.com',
+            'amount': '75.00',
+            'currency': 'USD',
+            'payment_method': 'fincra',
+            'first_name': 'Ada',
+            'last_name': 'Lovelace',
+            'country': 'GB',
+        },
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == 'https://fincra.test/checkout'
+    assert captured['json']['customer']['firstName'] == 'Ada'
+    assert captured['timeout'] == 10
+
     with app.app_context():
-        donation = Donation.query.filter_by(email='flutter@example.com').first()
+        donation = Donation.query.filter_by(email='fincra-success@example.com').first()
         assert donation is not None
-        assert donation.payment_method == 'flutterwave'
+        assert donation.transaction_id == 'txn-789'
+        assert donation.payment_info['first_name'] == 'Ada'
+        assert donation.payment_info['authorization_url'] == 'https://fincra.test/checkout'
+        assert donation.payment_info['provider_response']['transactionReference'] == 'txn-789'
+        assert donation.status == 'pending'
+
+
+def test_fincra_timeout_marks_failed(monkeypatch, client, app):
+    token = get_token(client, '/donate')
+
+    def mock_post(url, headers=None, json=None, data=None, timeout=None):
+        raise Timeout('timed out')
+
+    monkeypatch.setattr('routes.donations.requests.post', mock_post)
+
+    resp = client.post(
+        '/donate/process',
+        data={
+            'csrf_token': token,
+            'email': 'fincra-timeout@example.com',
+            'amount': '40.00',
+            'currency': 'USD',
+            'payment_method': 'fincra',
+            'first_name': 'Ada',
+            'last_name': 'Lovelace',
+            'country': 'GB',
+        },
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == '/donate'
+
+    with app.app_context():
+        donation = Donation.query.filter_by(email='fincra-timeout@example.com').first()
+        assert donation is not None
+        assert donation.status == 'failed'
+        assert donation.error_message == 'Request to Fincra initialize endpoint timed out.'
+        assert donation.payment_info['first_name'] == 'Ada'
+        assert donation.transaction_id is None
+
+
+def test_stripe_success_redirects_to_checkout(monkeypatch, client, app):
+    token = get_token(client, '/donate')
+    captured = {}
+
+    def mock_post(url, headers=None, json=None, data=None, timeout=None):
+        captured['url'] = url
+        captured['headers'] = headers
+        captured['json'] = json
+        captured['data'] = data
+        captured['timeout'] = timeout
+        return DummyResponse(200, {'url': 'https://stripe.test/session', 'id': 'cs_test'})
+
+    monkeypatch.setattr('routes.donations.requests.post', mock_post)
+
+    resp = client.post(
+        '/donate/process',
+        data={
+            'csrf_token': token,
+            'email': 'stripe-success@example.com',
+            'amount': '15.00',
+            'currency': 'USD',
+            'payment_method': 'stripe',
+        },
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == 'https://stripe.test/session'
+    assert captured['timeout'] == 10
+    assert captured['data']['line_items[0][price_data][currency]'] == 'usd'
+
+    with app.app_context():
+        donation = Donation.query.filter_by(email='stripe-success@example.com').first()
+        assert donation is not None
+        assert donation.transaction_id == 'cs_test'
+        assert donation.payment_info['authorization_url'] == 'https://stripe.test/session'
+        assert donation.payment_info['provider_response']['id'] == 'cs_test'
+        assert donation.status == 'pending'
+
+
+def test_stripe_failure_marks_donation_failed(monkeypatch, client, app):
+    token = get_token(client, '/donate')
+
+    def mock_post(url, headers=None, json=None, data=None, timeout=None):
+        return DummyResponse(500, {'error': 'server'})
+
+    monkeypatch.setattr('routes.donations.requests.post', mock_post)
+
+    resp = client.post(
+        '/donate/process',
+        data={
+            'csrf_token': token,
+            'email': 'stripe-failure@example.com',
+            'amount': '25.00',
+            'currency': 'USD',
+            'payment_method': 'stripe',
+        },
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == '/donate'
+
+    with app.app_context():
+        donation = Donation.query.filter_by(email='stripe-failure@example.com').first()
+        assert donation is not None
+        assert donation.status == 'failed'
+        assert 'Non-200 response (500)' in donation.error_message
+        assert donation.transaction_id is None
+        assert 'stripe_error' in donation.payment_info
+
+
+def test_flutterwave_success_redirects_to_checkout(monkeypatch, client, app):
+    token = get_token(client, '/donate')
+    captured = {}
+
+    def mock_post(url, headers=None, json=None, data=None, timeout=None):
+        captured['url'] = url
+        captured['headers'] = headers
+        captured['json'] = json
+        captured['timeout'] = timeout
+        return DummyResponse(
+            200,
+            {
+                'data': {
+                    'link': 'https://flutterwave.test/pay',
+                    'id': 'flw-456',
+                }
+            },
+        )
+
+    monkeypatch.setattr('routes.donations.requests.post', mock_post)
+
+    resp = client.post(
+        '/donate/process',
+        data={
+            'csrf_token': token,
+            'email': 'flutterwave-success@example.com',
+            'amount': '35.00',
+            'currency': 'USD',
+            'payment_method': 'flutterwave',
+        },
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == 'https://flutterwave.test/pay'
+    assert captured['json']['payment_options'] == 'card'
+    assert captured['timeout'] == 10
+
+    with app.app_context():
+        donation = Donation.query.filter_by(email='flutterwave-success@example.com').first()
+        assert donation is not None
+        assert donation.transaction_id == 'flw-456'
+        assert donation.payment_info['authorization_url'] == 'https://flutterwave.test/pay'
+        assert donation.payment_info['provider_response']['id'] == 'flw-456'
+        assert donation.status == 'pending'
+
+
+def test_flutterwave_request_exception_marks_failed(monkeypatch, client, app):
+    token = get_token(client, '/donate')
+
+    def mock_post(url, headers=None, json=None, data=None, timeout=None):
+        raise RequestException('boom')
+
+    monkeypatch.setattr('routes.donations.requests.post', mock_post)
+
+    resp = client.post(
+        '/donate/process',
+        data={
+            'csrf_token': token,
+            'email': 'flutterwave-failure@example.com',
+            'amount': '45.00',
+            'currency': 'USD',
+            'payment_method': 'flutterwave',
+        },
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == '/donate'
+
+    with app.app_context():
+        donation = Donation.query.filter_by(email='flutterwave-failure@example.com').first()
+        assert donation is not None
+        assert donation.status == 'failed'
+        assert 'Request to Flutterwave failed: boom' in donation.error_message
+        assert donation.transaction_id is None


### PR DESCRIPTION
## Summary
- add the requests HTTP client dependency to support outbound payment provider calls
- implement real initialization requests for Paystack, Fincra, Stripe, and Flutterwave with error handling and donation metadata updates
- update fixtures and add success/failure unit tests for each provider using mocked HTTP responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc2229b170833381af116f0bcf2dd4