### PR TITLE
Scaffold TypeScript rewrite for Covenant Connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,15 @@ ENV/
 .env
 .env.local
 *.sqlite3
+node_modules/
+.next/
+apps/**/dist/
+apps/**/.turbo/
+apps/**/coverage/
+packages/**/dist/
+pnpm-lock.yaml
+package-lock.json
+yarn.lock
 
 # Replit specific
 .config/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # Covenant Connect
 
 This project powers the Covenant Connect ministry management application.  The
-application is built with Flask and SQLAlchemy and ships with a helper script
-for provisioning the first administrator account in a brand-new deployment.
+legacy application is built with Flask and SQLAlchemy and ships with a helper
+script for provisioning the first administrator account in a brand-new
+deployment.
+
+> **New TypeScript rewrite**
+>
+> A greenfield JavaScript/TypeScript implementation now lives under
+> [`apps/backend`](apps/backend) and [`apps/frontend`](apps/frontend). The NestJS
+> backend exposes modular services for authentication, donations, events,
+> prayer, content, and reporting while the Next.js frontend provides the
+> landing experience and an operational dashboard. Shared domain interfaces are
+> published from [`packages/shared`](packages/shared), and the architecture is
+> documented in [docs/js-architecture.md](docs/js-architecture.md).
 
 ## Environment configuration
 

--- a/apps/backend/.eslintrc.cjs
+++ b/apps/backend/.eslintrc.cjs
@@ -1,0 +1,30 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    jest: false
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json']
+  },
+  plugins: ['@typescript-eslint', 'import'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
+    'prettier'
+  ],
+  rules: {
+    'import/order': [
+      'error',
+      {
+        groups: [['builtin', 'external'], 'internal', ['parent', 'sibling', 'index']],
+        'newlines-between': 'always'
+      }
+    ],
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-explicit-any': 'off'
+  }
+};

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@covenant-connect/backend",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "ts-node-dev --respawn --transpile-only src/main.ts",
+    "start": "node dist/main.js",
+    "lint": "eslint --ext .ts src",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.3.3",
+    "@nestjs/config": "^3.1.1",
+    "@nestjs/core": "^10.3.3",
+    "@nestjs/platform-express": "^10.3.3",
+    "@nestjs/terminus": "^10.2.1",
+    "@prisma/client": "^5.6.0",
+    "argon2": "^0.31.2",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "cookie-parser": "^1.4.6",
+    "express-session": "^1.17.3",
+    "helmet": "^7.0.0",
+    "nestjs-prisma": "^3.1.0",
+    "pino": "^8.15.0",
+    "pino-pretty": "^10.2.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "stripe": "^14.0.0"
+  },
+  "devDependencies": {
+    "@nestjs/testing": "^10.3.3",
+    "@types/express": "^4.17.21",
+    "@types/express-session": "^1.17.7",
+    "@types/node": "^20.9.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.5",
+    "@typescript-eslint/parser": "^6.7.5",
+    "eslint": "^8.53.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-import": "^2.29.0",
+    "prettier": "^3.0.3",
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.2.2",
+    "vitest": "^0.34.5"
+  }
+}

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,0 +1,42 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TerminusModule } from '@nestjs/terminus';
+
+import configuration from './config/configuration';
+import { healthConfig } from './config/health.config';
+import { securityConfig } from './config/security.config';
+import { storageConfig } from './config/storage.config';
+import { automationConfig } from './config/automation.config';
+import { AuthModule } from './modules/auth/auth.module';
+import { ChurchesModule } from './modules/churches/churches.module';
+import { ContentModule } from './modules/content/content.module';
+import { DonationsModule } from './modules/donations/donations.module';
+import { EmailModule } from './modules/email/email.module';
+import { EventsModule } from './modules/events/events.module';
+import { HealthModule } from './modules/health/health.module';
+import { IntegrationsModule } from './modules/integrations/integrations.module';
+import { PrayerModule } from './modules/prayer/prayer.module';
+import { ReportsModule } from './modules/reports/reports.module';
+import { TasksModule } from './modules/tasks/tasks.module';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [configuration, healthConfig, securityConfig, storageConfig, automationConfig]
+    }),
+    TerminusModule,
+    HealthModule,
+    AuthModule,
+    DonationsModule,
+    PrayerModule,
+    EventsModule,
+    ReportsModule,
+    ContentModule,
+    ChurchesModule,
+    EmailModule,
+    IntegrationsModule,
+    TasksModule
+  ]
+})
+export class AppModule {}

--- a/apps/backend/src/config/automation.config.ts
+++ b/apps/backend/src/config/automation.config.ts
@@ -1,0 +1,25 @@
+import { registerAs } from '@nestjs/config';
+
+type AutomationConfig = {
+  queue: {
+    driver: 'redis' | 'memory';
+    redisUrl: string | null;
+    defaultAttempts: number;
+  };
+  schedules: {
+    kpiDigestCron: string;
+    followUpCron: string;
+  };
+};
+
+export const automationConfig = registerAs<AutomationConfig>('automation', () => ({
+  queue: {
+    driver: (process.env.QUEUE_DRIVER as 'redis' | 'memory') ?? 'memory',
+    redisUrl: process.env.REDIS_URL ?? null,
+    defaultAttempts: Number.parseInt(process.env.QUEUE_MAX_ATTEMPTS ?? '3', 10)
+  },
+  schedules: {
+    kpiDigestCron: process.env.KPI_DIGEST_CRON ?? '0 7 * * 1',
+    followUpCron: process.env.FOLLOW_UP_CRON ?? '0 */6 * * *'
+  }
+}));

--- a/apps/backend/src/config/configuration.ts
+++ b/apps/backend/src/config/configuration.ts
@@ -1,0 +1,76 @@
+import { registerAs } from '@nestjs/config';
+
+type HttpConfig = {
+  port: number;
+  cors: string[];
+  cookieDomain: string | null;
+};
+
+type PaymentsConfig = {
+  stripeKey: string | null;
+  paystackKey: string | null;
+  flutterwaveKey: string | null;
+  fincraKey: string | null;
+};
+
+type IntegrationsConfig = {
+  googleClientId: string | null;
+  googleClientSecret: string | null;
+  facebookClientId: string | null;
+  facebookClientSecret: string | null;
+  appleTeamId: string | null;
+  appleKeyId: string | null;
+  applePrivateKey: string | null;
+};
+
+export type ApplicationConfig = {
+  name: string;
+  environment: string;
+  version: string;
+  http: HttpConfig;
+  databaseUrl: string | null;
+  redisUrl: string | null;
+  payments: PaymentsConfig;
+  integrations: IntegrationsConfig;
+  assetBaseUrl: string | null;
+};
+
+const parseCorsOrigins = (value: string | undefined): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+};
+
+export default registerAs<ApplicationConfig>('application', () => ({
+  name: process.env.APP_NAME ?? 'Covenant Connect',
+  environment: process.env.NODE_ENV ?? 'development',
+  version: process.env.APP_VERSION ?? '0.0.1',
+  http: {
+    port: Number.parseInt(process.env.PORT ?? '8000', 10),
+    cors: parseCorsOrigins(process.env.CORS_ORIGINS),
+    cookieDomain: process.env.COOKIE_DOMAIN ?? null
+  },
+  databaseUrl: process.env.DATABASE_URL ?? null,
+  redisUrl: process.env.REDIS_URL ?? null,
+  payments: {
+    stripeKey: process.env.STRIPE_SECRET_KEY ?? null,
+    paystackKey: process.env.PAYSTACK_SECRET_KEY ?? null,
+    flutterwaveKey: process.env.FLUTTERWAVE_SECRET_KEY ?? null,
+    fincraKey: process.env.FINCRA_SECRET_KEY ?? null
+  },
+  integrations: {
+    googleClientId: process.env.GOOGLE_CLIENT_ID ?? null,
+    googleClientSecret: process.env.GOOGLE_CLIENT_SECRET ?? null,
+    facebookClientId: process.env.FACEBOOK_CLIENT_ID ?? null,
+    facebookClientSecret: process.env.FACEBOOK_CLIENT_SECRET ?? null,
+    appleTeamId: process.env.APPLE_TEAM_ID ?? null,
+    appleKeyId: process.env.APPLE_KEY_ID ?? null,
+    applePrivateKey: process.env.APPLE_PRIVATE_KEY ?? null
+  },
+  assetBaseUrl: process.env.ASSET_BASE_URL ?? null
+}));

--- a/apps/backend/src/config/health.config.ts
+++ b/apps/backend/src/config/health.config.ts
@@ -1,0 +1,21 @@
+import { registerAs } from '@nestjs/config';
+
+type HealthIndicatorConfig = {
+  database: boolean;
+  redis: boolean;
+};
+
+type HealthConfig = {
+  livenessKey: string;
+  readinessKey: string;
+  indicators: HealthIndicatorConfig;
+};
+
+export const healthConfig = registerAs<HealthConfig>('health', () => ({
+  livenessKey: process.env.HEALTH_LIVENESS_KEY ?? 'covenant-connect:liveness',
+  readinessKey: process.env.HEALTH_READINESS_KEY ?? 'covenant-connect:readiness',
+  indicators: {
+    database: process.env.HEALTH_DATABASE_ENABLED !== 'false',
+    redis: process.env.HEALTH_REDIS_ENABLED !== 'false'
+  }
+}));

--- a/apps/backend/src/config/security.config.ts
+++ b/apps/backend/src/config/security.config.ts
@@ -1,0 +1,18 @@
+import { registerAs } from '@nestjs/config';
+
+type SessionConfig = {
+  secret: string;
+  secureCookies: boolean;
+  ttlSeconds: number;
+};
+
+export const securityConfig = registerAs('security', () => ({
+  session: {
+    secret: process.env.SESSION_SECRET ?? 'change-me',
+    secureCookies: process.env.COOKIE_SECURE === 'true',
+    ttlSeconds: Number.parseInt(process.env.SESSION_TTL ?? '604800', 10)
+  },
+  csrf: {
+    enabled: process.env.CSRF_ENABLED !== 'false'
+  }
+}));

--- a/apps/backend/src/config/storage.config.ts
+++ b/apps/backend/src/config/storage.config.ts
@@ -1,0 +1,39 @@
+import { registerAs } from '@nestjs/config';
+
+type StorageDrivers = 's3' | 'local';
+
+type StorageConfig = {
+  driver: StorageDrivers;
+  s3?: {
+    bucket: string;
+    region: string;
+    accessKeyId: string;
+    secretAccessKey: string;
+  };
+  local?: {
+    directory: string;
+  };
+};
+
+export const storageConfig = registerAs<StorageConfig>('storage', () => {
+  const driver = (process.env.STORAGE_DRIVER ?? 'local') as StorageDrivers;
+
+  if (driver === 's3') {
+    return {
+      driver,
+      s3: {
+        bucket: process.env.AWS_S3_BUCKET ?? '',
+        region: process.env.AWS_REGION ?? 'us-east-1',
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? ''
+      }
+    } satisfies StorageConfig;
+  }
+
+  return {
+    driver: 'local',
+    local: {
+      directory: process.env.LOCAL_STORAGE_DIR ?? './uploads'
+    }
+  } satisfies StorageConfig;
+});

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,0 +1,33 @@
+import 'reflect-metadata';
+
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { NestFactory } from '@nestjs/core';
+import helmet from 'helmet';
+
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, {
+    bufferLogs: true
+  });
+
+  const configService = app.get(ConfigService);
+  const port = configService.get<number>('application.http.port', 8000);
+  const corsOrigins = configService.get<string[]>('application.http.cors', []);
+
+  app.useLogger(app.get(Logger));
+  app.use(helmet());
+  app.enableCors({
+    origin: corsOrigins,
+    credentials: true
+  });
+
+  await app.listen(port);
+  Logger.log(`Covenant Connect API listening on port ${port}`, 'Bootstrap');
+}
+
+bootstrap().catch((error) => {
+  Logger.error('Fatal error during Nest bootstrap', error.stack);
+  process.exit(1);
+});

--- a/apps/backend/src/modules/accounts/accounts.module.ts
+++ b/apps/backend/src/modules/accounts/accounts.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { AccountsRepository } from './accounts.repository';
+import { AccountsService } from './accounts.service';
+
+@Module({
+  providers: [AccountsRepository, AccountsService],
+  exports: [AccountsService]
+})
+export class AccountsModule {}

--- a/apps/backend/src/modules/accounts/accounts.repository.ts
+++ b/apps/backend/src/modules/accounts/accounts.repository.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+
+import type { Provider, ProviderIdentity, UserAccount } from '@covenant-connect/shared';
+
+@Injectable()
+export class AccountsRepository {
+  private readonly accounts = new Map<string, UserAccount>();
+
+  async list(): Promise<UserAccount[]> {
+    return Array.from(this.accounts.values());
+  }
+
+  async findById(id: string): Promise<UserAccount | null> {
+    return this.accounts.get(id) ?? null;
+  }
+
+  async findByEmail(email: string): Promise<UserAccount | null> {
+    const normalised = email.toLowerCase();
+    return (
+      Array.from(this.accounts.values()).find((account) => account.email.toLowerCase() === normalised) ??
+      null
+    );
+  }
+
+  async findByProvider(provider: Provider, providerId: string): Promise<UserAccount | null> {
+    return (
+      Array.from(this.accounts.values()).find((account) =>
+        account.providers.some((identity) => identity.provider === provider && identity.providerId === providerId)
+      ) ?? null
+    );
+  }
+
+  async create(data: Omit<UserAccount, 'id' | 'createdAt' | 'updatedAt'>): Promise<UserAccount> {
+    const now = new Date();
+    const account: UserAccount = {
+      id: randomUUID(),
+      createdAt: now,
+      updatedAt: now,
+      ...data
+    };
+
+    this.accounts.set(account.id, account);
+    return account;
+  }
+
+  async update(accountId: string, data: Partial<UserAccount>): Promise<UserAccount | null> {
+    const account = await this.findById(accountId);
+    if (!account) {
+      return null;
+    }
+
+    const updated: UserAccount = {
+      ...account,
+      ...data,
+      updatedAt: new Date()
+    };
+
+    this.accounts.set(updated.id, updated);
+    return updated;
+  }
+
+  async linkProvider(accountId: string, provider: ProviderIdentity): Promise<UserAccount | null> {
+    const account = await this.findById(accountId);
+    if (!account) {
+      return null;
+    }
+
+    const others = account.providers.filter((identity) => identity.provider !== provider.provider);
+    const updated: UserAccount = {
+      ...account,
+      providers: [...others, provider],
+      updatedAt: new Date()
+    };
+
+    this.accounts.set(updated.id, updated);
+    return updated;
+  }
+}

--- a/apps/backend/src/modules/accounts/accounts.service.ts
+++ b/apps/backend/src/modules/accounts/accounts.service.ts
@@ -1,0 +1,82 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import argon2 from 'argon2';
+
+import type { Provider, ProviderIdentity, UserAccount } from '@covenant-connect/shared';
+
+import { AccountsRepository } from './accounts.repository';
+
+type CreateAccountInput = {
+  email: string;
+  password?: string;
+  firstName: string;
+  lastName: string;
+  roles?: string[];
+  provider?: ProviderIdentity;
+};
+
+type UpdateAccountInput = Partial<Pick<UserAccount, 'firstName' | 'lastName' | 'avatarUrl' | 'roles'>>;
+
+@Injectable()
+export class AccountsService {
+  constructor(private readonly repository: AccountsRepository) {}
+
+  async createAccount(input: CreateAccountInput): Promise<UserAccount> {
+    const existing = await this.repository.findByEmail(input.email);
+    if (existing) {
+      throw new ConflictException('An account already exists for this email');
+    }
+
+    const passwordHash = input.password ? await argon2.hash(input.password) : undefined;
+
+    return this.repository.create({
+      email: input.email,
+      passwordHash,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      roles: input.roles ?? ['member'],
+      providers: input.provider ? [input.provider] : []
+    });
+  }
+
+  async listAccounts(): Promise<UserAccount[]> {
+    return this.repository.list();
+  }
+
+  async getAccountById(accountId: string): Promise<UserAccount | null> {
+    return this.repository.findById(accountId);
+  }
+
+  async getAccountByEmail(email: string): Promise<UserAccount | null> {
+    return this.repository.findByEmail(email);
+  }
+
+  async getAccountByProvider(provider: Provider, providerId: string): Promise<UserAccount | null> {
+    return this.repository.findByProvider(provider, providerId);
+  }
+
+  async updateAccount(accountId: string, input: UpdateAccountInput): Promise<UserAccount> {
+    const account = await this.repository.update(accountId, input);
+    if (!account) {
+      throw new NotFoundException('Account not found');
+    }
+
+    return account;
+  }
+
+  async linkProvider(accountId: string, provider: ProviderIdentity): Promise<UserAccount> {
+    const account = await this.repository.linkProvider(accountId, provider);
+    if (!account) {
+      throw new NotFoundException('Account not found');
+    }
+
+    return account;
+  }
+
+  async verifyPassword(account: UserAccount, password: string): Promise<boolean> {
+    if (!account.passwordHash) {
+      return false;
+    }
+
+    return argon2.verify(account.passwordHash, password);
+  }
+}

--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -1,0 +1,72 @@
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+
+import type { Provider, UserAccount } from '@covenant-connect/shared';
+
+import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
+import { ProviderCallbackDto } from './dto/provider-callback.dto';
+import { RegisterDto } from './dto/register.dto';
+import { StartSocialLoginDto } from './dto/start-social-login.dto';
+import type { Session } from './session.store';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  async register(@Body() dto: RegisterDto): Promise<{ account: UserAccount; session: Session }> {
+    return this.authService.register(dto);
+  }
+
+  @Post('login')
+  async login(@Body() dto: LoginDto): Promise<{ account: UserAccount; session: Session }> {
+    return this.authService.login(dto.email, dto.password);
+  }
+
+  @Post('logout')
+  async logout(@Body('token') token: string): Promise<{ success: boolean }> {
+    await this.authService.logout(token);
+    return { success: true };
+  }
+
+  @Get('session/:token')
+  async getSession(@Param('token') token: string): Promise<UserAccount | null> {
+    return this.authService.resolveSession(token);
+  }
+
+  @Get('providers/:provider/authorize')
+  async startProviderLogin(
+    @Param('provider') provider: string,
+    @Query() query: StartSocialLoginDto
+  ): Promise<{ authorizationUrl: string; state: string }> {
+    return this.authService.startProviderLogin(this.mapProvider(provider), query.redirectUri, query.state);
+  }
+
+  @Post('providers/:provider/callback')
+  async providerCallback(
+    @Param('provider') provider: string,
+    @Body() body: ProviderCallbackDto
+  ): Promise<{ account: UserAccount; session: Session; redirectUri?: string }> {
+    // TODO: Replace with real provider integration that exchanges `code` for a profile.
+    const mockProfile = {
+      providerId: body.code,
+      email: `${body.code}@${provider}.oauth`,
+      firstName: provider.charAt(0).toUpperCase() + provider.slice(1),
+      lastName: 'User'
+    };
+
+    return this.authService.completeProviderLogin(
+      this.mapProvider(provider),
+      mockProfile,
+      body.state
+    );
+  }
+
+  private mapProvider(provider: string): Provider {
+    if (provider === 'google' || provider === 'facebook' || provider === 'apple' || provider === 'password') {
+      return provider;
+    }
+
+    throw new Error(`Unsupported provider: ${provider}`);
+  }
+}

--- a/apps/backend/src/modules/auth/auth.module.ts
+++ b/apps/backend/src/modules/auth/auth.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
+import { AccountsModule } from '../accounts/accounts.module';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { SessionStore } from './session.store';
+
+@Module({
+  imports: [ConfigModule, AccountsModule],
+  controllers: [AuthController],
+  providers: [AuthService, SessionStore],
+  exports: [AuthService]
+})
+export class AuthModule {}

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -1,0 +1,160 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import type { Provider, ProviderIdentity, UserAccount } from '@covenant-connect/shared';
+
+import { AccountsService } from '../accounts/accounts.service';
+import { RegisterDto } from './dto/register.dto';
+import { Session, SessionStore } from './session.store';
+
+type LoginResult = {
+  account: UserAccount;
+  session: Session;
+};
+
+type ProviderProfile = {
+  providerId: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  avatarUrl?: string;
+};
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly accounts: AccountsService,
+    private readonly sessions: SessionStore,
+    private readonly configService: ConfigService
+  ) {}
+
+  async register(payload: RegisterDto): Promise<LoginResult> {
+    const account = await this.accounts.createAccount({
+      email: payload.email,
+      password: payload.password,
+      firstName: payload.firstName,
+      lastName: payload.lastName,
+      roles: payload.roles
+    });
+
+    const session = this.issueSession(account.id);
+    return { account, session };
+  }
+
+  async login(email: string, password: string): Promise<LoginResult> {
+    const account = await this.accounts.getAccountByEmail(email);
+    if (!account) {
+      throw new UnauthorizedException('Invalid email or password');
+    }
+
+    const isValid = await this.accounts.verifyPassword(account, password);
+    if (!isValid) {
+      throw new UnauthorizedException('Invalid email or password');
+    }
+
+    const session = this.issueSession(account.id);
+    return { account, session };
+  }
+
+  async resolveSession(token: string): Promise<UserAccount | null> {
+    const session = this.sessions.get(token);
+    if (!session) {
+      return null;
+    }
+
+    return this.accounts.getAccountById(session.userId);
+  }
+
+  async startProviderLogin(provider: Provider, redirectUri?: string, state?: string): Promise<{
+    authorizationUrl: string;
+    state: string;
+  }> {
+    const stateToken = Buffer.from(JSON.stringify({ redirectUri, state })).toString('base64url');
+    const baseUrl = this.providerBaseUrl(provider);
+    const authorizationUrl = `${baseUrl}?state=${stateToken}`;
+
+    return {
+      authorizationUrl,
+      state: stateToken
+    };
+  }
+
+  async completeProviderLogin(
+    provider: Provider,
+    profile: ProviderProfile,
+    stateToken?: string
+  ): Promise<{ account: UserAccount; session: Session; redirectUri?: string }> {
+    let account = await this.accounts.getAccountByProvider(provider, profile.providerId);
+
+    if (!account) {
+      const providerIdentity: ProviderIdentity = {
+        provider,
+        providerId: profile.providerId,
+        accessToken: 'mock-access-token'
+      };
+
+      account = await this.accounts.createAccount({
+        email: profile.email,
+        firstName: profile.firstName,
+        lastName: profile.lastName,
+        provider: providerIdentity,
+        roles: ['member']
+      });
+    } else {
+      await this.accounts.linkProvider(account.id, {
+        provider,
+        providerId: profile.providerId,
+        accessToken: 'mock-access-token'
+      });
+    }
+
+    const session = this.issueSession(account.id);
+    const redirectUri = this.extractRedirect(stateToken);
+
+    return { account, session, redirectUri };
+  }
+
+  async logout(token: string): Promise<void> {
+    this.sessions.revoke(token);
+  }
+
+  private issueSession(accountId: string): Session {
+    const ttl = this.configService.get<number>('security.session.ttlSeconds', 60 * 60 * 24 * 7);
+    return this.sessions.create(accountId, ttl);
+  }
+
+  private providerBaseUrl(provider: Provider): string {
+    const overrides: Record<Provider, string> = {
+      google: 'https://accounts.google.com/o/oauth2/v2/auth',
+      facebook: 'https://www.facebook.com/v14.0/dialog/oauth',
+      apple: 'https://appleid.apple.com/auth/authorize',
+      password: ''
+    };
+
+    return overrides[provider];
+  }
+
+  private extractRedirect(stateToken?: string): string | undefined {
+    if (!stateToken) {
+      return undefined;
+    }
+
+    try {
+      const decoded = JSON.parse(Buffer.from(stateToken, 'base64url').toString());
+      const redirectUri: string | undefined = decoded.redirectUri;
+      if (!redirectUri) {
+        return undefined;
+      }
+
+      const allowedOrigins = this.configService.get<string[]>('application.http.cors', []);
+      const parsed = new URL(redirectUri);
+      if (allowedOrigins.length > 0 && !allowedOrigins.includes(parsed.origin)) {
+        return undefined;
+      }
+
+      return redirectUri;
+    } catch (error) {
+      return undefined;
+    }
+  }
+}

--- a/apps/backend/src/modules/auth/dto/login.dto.ts
+++ b/apps/backend/src/modules/auth/dto/login.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @MinLength(8)
+  password!: string;
+}

--- a/apps/backend/src/modules/auth/dto/provider-callback.dto.ts
+++ b/apps/backend/src/modules/auth/dto/provider-callback.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class ProviderCallbackDto {
+  @IsString()
+  code!: string;
+
+  @IsOptional()
+  @IsString()
+  state?: string;
+}

--- a/apps/backend/src/modules/auth/dto/register.dto.ts
+++ b/apps/backend/src/modules/auth/dto/register.dto.ts
@@ -1,0 +1,20 @@
+import { IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class RegisterDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @MinLength(8)
+  password!: string;
+
+  @IsString()
+  firstName!: string;
+
+  @IsString()
+  lastName!: string;
+
+  @IsOptional()
+  @IsString({ each: true })
+  roles?: string[];
+}

--- a/apps/backend/src/modules/auth/dto/start-social-login.dto.ts
+++ b/apps/backend/src/modules/auth/dto/start-social-login.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class StartSocialLoginDto {
+  @IsOptional()
+  @IsUrl({ require_protocol: true })
+  redirectUri?: string;
+
+  @IsOptional()
+  @IsString()
+  state?: string;
+}

--- a/apps/backend/src/modules/auth/session.store.ts
+++ b/apps/backend/src/modules/auth/session.store.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
+
+export type Session = {
+  token: string;
+  userId: string;
+  createdAt: Date;
+  expiresAt: Date;
+};
+
+@Injectable()
+export class SessionStore {
+  private readonly sessions = new Map<string, Session>();
+
+  create(userId: string, ttlSeconds: number): Session {
+    const token = randomBytes(48).toString('hex');
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + ttlSeconds * 1000);
+
+    const session: Session = {
+      token,
+      userId,
+      createdAt: now,
+      expiresAt
+    };
+
+    this.sessions.set(token, session);
+    return session;
+  }
+
+  get(token: string): Session | null {
+    const session = this.sessions.get(token);
+    if (!session) {
+      return null;
+    }
+
+    if (session.expiresAt.getTime() < Date.now()) {
+      this.sessions.delete(token);
+      return null;
+    }
+
+    return session;
+  }
+
+  revoke(token: string): void {
+    this.sessions.delete(token);
+  }
+}

--- a/apps/backend/src/modules/churches/churches.controller.ts
+++ b/apps/backend/src/modules/churches/churches.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+
+import type { Church } from '@covenant-connect/shared';
+
+import { ChurchesService } from './churches.service';
+
+@Controller('churches')
+export class ChurchesController {
+  constructor(private readonly churches: ChurchesService) {}
+
+  @Post()
+  create(@Body() body: { name: string; timezone: string; country?: string; state?: string; city?: string }): Promise<Church> {
+    return this.churches.create(body);
+  }
+
+  @Get()
+  list(): Promise<Church[]> {
+    return this.churches.list();
+  }
+
+  @Get(':id')
+  getById(@Param('id') id: string): Promise<Church> {
+    return this.churches.getById(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() body: Partial<Church>): Promise<Church> {
+    return this.churches.update(id, body);
+  }
+}

--- a/apps/backend/src/modules/churches/churches.module.ts
+++ b/apps/backend/src/modules/churches/churches.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { ChurchesController } from './churches.controller';
+import { ChurchesService } from './churches.service';
+
+@Module({
+  controllers: [ChurchesController],
+  providers: [ChurchesService],
+  exports: [ChurchesService]
+})
+export class ChurchesModule {}

--- a/apps/backend/src/modules/churches/churches.service.ts
+++ b/apps/backend/src/modules/churches/churches.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+
+import type { Church } from '@covenant-connect/shared';
+
+type CreateChurchInput = {
+  name: string;
+  timezone: string;
+  country?: string;
+  state?: string;
+  city?: string;
+  settings?: Record<string, unknown>;
+};
+
+type UpdateChurchInput = Partial<CreateChurchInput>;
+
+@Injectable()
+export class ChurchesService {
+  private readonly churches = new Map<string, Church>();
+
+  async create(input: CreateChurchInput): Promise<Church> {
+    const now = new Date();
+    const church: Church = {
+      id: randomUUID(),
+      name: input.name,
+      timezone: input.timezone,
+      country: input.country,
+      state: input.state,
+      city: input.city,
+      settings: input.settings ?? {},
+      createdAt: now,
+      updatedAt: now
+    };
+
+    this.churches.set(church.id, church);
+    return church;
+  }
+
+  async list(): Promise<Church[]> {
+    return Array.from(this.churches.values());
+  }
+
+  async getById(churchId: string): Promise<Church> {
+    const church = this.churches.get(churchId);
+    if (!church) {
+      throw new NotFoundException('Church not found');
+    }
+
+    return church;
+  }
+
+  async update(churchId: string, input: UpdateChurchInput): Promise<Church> {
+    const existing = await this.getById(churchId);
+
+    const updated: Church = {
+      ...existing,
+      ...input,
+      settings: { ...existing.settings, ...(input.settings ?? {}) },
+      updatedAt: new Date()
+    };
+
+    this.churches.set(updated.id, updated);
+    return updated;
+  }
+}

--- a/apps/backend/src/modules/content/content.controller.ts
+++ b/apps/backend/src/modules/content/content.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Get, Post, Put } from '@nestjs/common';
+
+import type { HomeContent, PaginatedResult, Sermon } from '@covenant-connect/shared';
+
+import { ContentService } from './content.service';
+
+@Controller('content')
+export class ContentController {
+  constructor(private readonly content: ContentService) {}
+
+  @Get('home')
+  getHome(): Promise<HomeContent> {
+    return this.content.getHome();
+  }
+
+  @Put('home')
+  updateHome(@Body() body: Partial<HomeContent>): Promise<HomeContent> {
+    return this.content.updateHome(body);
+  }
+
+  @Get('sermons')
+  listSermons(): Promise<PaginatedResult<Sermon>> {
+    return this.content.listSermons();
+  }
+
+  @Post('sermons')
+  addSermon(@Body() sermon: Sermon): Promise<{ success: boolean }> {
+    return this.content.addSermon(sermon).then(() => ({ success: true }));
+  }
+}

--- a/apps/backend/src/modules/content/content.module.ts
+++ b/apps/backend/src/modules/content/content.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { ContentController } from './content.controller';
+import { ContentService } from './content.service';
+
+@Module({
+  controllers: [ContentController],
+  providers: [ContentService],
+  exports: [ContentService]
+})
+export class ContentModule {}

--- a/apps/backend/src/modules/content/content.service.ts
+++ b/apps/backend/src/modules/content/content.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+
+import type { HomeContent, PaginatedResult, Sermon } from '@covenant-connect/shared';
+
+@Injectable()
+export class ContentService {
+  private readonly sermons: Sermon[] = [];
+  private homeContent: HomeContent = {
+    heroTitle: 'Welcome to Covenant Connect',
+    heroSubtitle: 'A modern ministry platform for churches.',
+    highlights: ['Plan services', 'Track follow-ups', 'Unify communications'],
+    nextSteps: [
+      { label: 'Plan a visit', url: '/plan-visit' },
+      { label: 'Give online', url: '/give' },
+      { label: 'Join a group', url: '/groups' }
+    ]
+  };
+
+  async getHome(): Promise<HomeContent> {
+    return this.homeContent;
+  }
+
+  async updateHome(content: Partial<HomeContent>): Promise<HomeContent> {
+    this.homeContent = { ...this.homeContent, ...content };
+    return this.homeContent;
+  }
+
+  async listSermons(): Promise<PaginatedResult<Sermon>> {
+    return {
+      data: this.sermons,
+      total: this.sermons.length,
+      page: 1,
+      pageSize: this.sermons.length || 1
+    };
+  }
+
+  async addSermon(sermon: Sermon): Promise<void> {
+    this.sermons.push(sermon);
+  }
+}

--- a/apps/backend/src/modules/donations/donations.controller.ts
+++ b/apps/backend/src/modules/donations/donations.controller.ts
@@ -1,0 +1,37 @@
+import { Body, Controller, Get, Param, Patch, Post, Query } from '@nestjs/common';
+
+import type { Donation, PaginatedResult } from '@covenant-connect/shared';
+
+import { DonationsService } from './donations.service';
+
+@Controller('donations')
+export class DonationsController {
+  constructor(private readonly donations: DonationsService) {}
+
+  @Get()
+  list(
+    @Query('page') page = '1',
+    @Query('pageSize') pageSize = '25'
+  ): Promise<PaginatedResult<Donation>> {
+    return this.donations.list({
+      page: Number.parseInt(page, 10),
+      pageSize: Number.parseInt(pageSize, 10)
+    });
+  }
+
+  @Post()
+  create(
+    @Body()
+    body: { amount: number; currency: string; provider: Donation['provider']; memberId?: string | null }
+  ): Promise<Donation> {
+    return this.donations.create(body);
+  }
+
+  @Patch(':id/status')
+  updateStatus(
+    @Param('id') id: string,
+    @Body() body: { status: Donation['status']; metadata?: Record<string, unknown> }
+  ): Promise<Donation> {
+    return this.donations.updateStatus(id, body);
+  }
+}

--- a/apps/backend/src/modules/donations/donations.module.ts
+++ b/apps/backend/src/modules/donations/donations.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { DonationsController } from './donations.controller';
+import { DonationsService } from './donations.service';
+
+@Module({
+  controllers: [DonationsController],
+  providers: [DonationsService],
+  exports: [DonationsService]
+})
+export class DonationsModule {}

--- a/apps/backend/src/modules/donations/donations.service.ts
+++ b/apps/backend/src/modules/donations/donations.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+
+import type { Donation, PaginatedResult, Pagination } from '@covenant-connect/shared';
+
+type CreateDonationInput = {
+  memberId?: string | null;
+  amount: number;
+  currency: string;
+  provider: Donation['provider'];
+  metadata?: Record<string, unknown>;
+};
+
+type UpdateDonationStatusInput = {
+  status: Donation['status'];
+  metadata?: Record<string, unknown>;
+};
+
+@Injectable()
+export class DonationsService {
+  private readonly donations = new Map<string, Donation>();
+
+  async list(pagination: Pagination): Promise<PaginatedResult<Donation>> {
+    const data = Array.from(this.donations.values());
+    const start = (pagination.page - 1) * pagination.pageSize;
+    const end = start + pagination.pageSize;
+
+    return {
+      data: data.slice(start, end),
+      total: data.length,
+      page: pagination.page,
+      pageSize: pagination.pageSize
+    };
+  }
+
+  async create(input: CreateDonationInput): Promise<Donation> {
+    const now = new Date();
+    const donation: Donation = {
+      id: randomUUID(),
+      memberId: input.memberId ?? null,
+      amount: input.amount,
+      currency: input.currency,
+      provider: input.provider,
+      status: 'pending',
+      metadata: input.metadata ?? {},
+      createdAt: now,
+      updatedAt: now
+    };
+
+    this.donations.set(donation.id, donation);
+    return donation;
+  }
+
+  async updateStatus(donationId: string, input: UpdateDonationStatusInput): Promise<Donation> {
+    const existing = this.donations.get(donationId);
+    if (!existing) {
+      throw new NotFoundException('Donation not found');
+    }
+
+    const updated: Donation = {
+      ...existing,
+      status: input.status,
+      metadata: { ...existing.metadata, ...(input.metadata ?? {}) },
+      updatedAt: new Date()
+    };
+
+    this.donations.set(updated.id, updated);
+    return updated;
+  }
+}

--- a/apps/backend/src/modules/email/email.controller.ts
+++ b/apps/backend/src/modules/email/email.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+
+import type { EmailProvider } from '@covenant-connect/shared';
+
+import { EmailService } from './email.service';
+
+@Controller('email')
+export class EmailController {
+  constructor(private readonly email: EmailService) {}
+
+  @Get('providers')
+  listProviders(): Promise<EmailProvider[]> {
+    return this.email.listProviders();
+  }
+
+  @Post('providers')
+  upsertProvider(
+    @Body() body: { id?: string; type: EmailProvider['type']; name: string; credentials: Record<string, string>; isActive?: boolean }
+  ): Promise<EmailProvider> {
+    return this.email.upsertProvider(body.id ?? null, body);
+  }
+
+  @Patch('providers/:id/activate')
+  activate(@Param('id') id: string): Promise<EmailProvider> {
+    return this.email.activate(id);
+  }
+
+  @Post('send')
+  send(@Body() body: { to: string; subject: string; html: string }): Promise<{ provider: EmailProvider }> {
+    return this.email.sendMail(body.to, body.subject, body.html);
+  }
+}

--- a/apps/backend/src/modules/email/email.module.ts
+++ b/apps/backend/src/modules/email/email.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { EmailController } from './email.controller';
+import { EmailService } from './email.service';
+
+@Module({
+  controllers: [EmailController],
+  providers: [EmailService],
+  exports: [EmailService]
+})
+export class EmailModule {}

--- a/apps/backend/src/modules/email/email.service.ts
+++ b/apps/backend/src/modules/email/email.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+
+import type { EmailProvider, EmailProviderType } from '@covenant-connect/shared';
+
+type UpsertProviderInput = {
+  type: EmailProviderType;
+  name: string;
+  credentials: Record<string, string>;
+  isActive?: boolean;
+};
+
+@Injectable()
+export class EmailService {
+  private readonly providers = new Map<string, EmailProvider>();
+
+  async listProviders(): Promise<EmailProvider[]> {
+    return Array.from(this.providers.values());
+  }
+
+  async upsertProvider(id: string | null, input: UpsertProviderInput): Promise<EmailProvider> {
+    const now = new Date();
+    const provider: EmailProvider = {
+      id: id ?? randomUUID(),
+      type: input.type,
+      name: input.name,
+      credentials: input.credentials,
+      isActive: input.isActive ?? true,
+      createdAt: now,
+      updatedAt: now
+    };
+
+    this.providers.set(provider.id, provider);
+    return provider;
+  }
+
+  async activate(providerId: string): Promise<EmailProvider> {
+    const provider = this.providers.get(providerId);
+    if (!provider) {
+      throw new NotFoundException('Email provider not found');
+    }
+
+    for (const existing of this.providers.values()) {
+      existing.isActive = existing.id === providerId;
+    }
+
+    provider.updatedAt = new Date();
+    this.providers.set(provider.id, provider);
+    return provider;
+  }
+
+  async sendMail(to: string, subject: string, html: string): Promise<{ provider: EmailProvider }> {
+    const activeProvider = Array.from(this.providers.values()).find((provider) => provider.isActive);
+    if (!activeProvider) {
+      throw new NotFoundException('No active email provider configured');
+    }
+
+    // TODO: integrate with actual provider SDKs; this is a placeholder implementation.
+    return { provider: activeProvider };
+  }
+}

--- a/apps/backend/src/modules/events/events.controller.ts
+++ b/apps/backend/src/modules/events/events.controller.ts
@@ -1,0 +1,62 @@
+import { Body, Controller, Get, Param, Patch, Post, Query, Res } from '@nestjs/common';
+import { Response } from 'express';
+
+import type { Event, PaginatedResult } from '@covenant-connect/shared';
+
+import { EventsService } from './events.service';
+
+@Controller('events')
+export class EventsController {
+  constructor(private readonly events: EventsService) {}
+
+  @Get()
+  list(
+    @Query('page') page = '1',
+    @Query('pageSize') pageSize = '25'
+  ): Promise<PaginatedResult<Event>> {
+    return this.events.list({
+      page: Number.parseInt(page, 10),
+      pageSize: Number.parseInt(pageSize, 10)
+    });
+  }
+
+  @Post()
+  create(
+    @Body()
+    body: {
+      title: string;
+      description?: string;
+      startsAt: string;
+      endsAt: string;
+      timezone: string;
+      recurrenceRule?: string;
+      tags?: string[];
+      location: string;
+    }
+  ): Promise<Event> {
+    return this.events.create({
+      ...body,
+      startsAt: new Date(body.startsAt),
+      endsAt: new Date(body.endsAt)
+    });
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() body: Partial<{ title: string; description: string; startsAt: string; endsAt: string; tags: string[] }>
+  ): Promise<Event> {
+    return this.events.update(id, {
+      ...body,
+      startsAt: body.startsAt ? new Date(body.startsAt) : undefined,
+      endsAt: body.endsAt ? new Date(body.endsAt) : undefined
+    });
+  }
+
+  @Get('calendar.ics')
+  async downloadCalendar(@Res() res: Response): Promise<void> {
+    const calendar = await this.events.toICalendar();
+    res.setHeader('Content-Type', 'text/calendar');
+    res.send(calendar);
+  }
+}

--- a/apps/backend/src/modules/events/events.module.ts
+++ b/apps/backend/src/modules/events/events.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { EventsController } from './events.controller';
+import { EventsService } from './events.service';
+
+@Module({
+  controllers: [EventsController],
+  providers: [EventsService],
+  exports: [EventsService]
+})
+export class EventsModule {}

--- a/apps/backend/src/modules/events/events.service.ts
+++ b/apps/backend/src/modules/events/events.service.ts
@@ -1,0 +1,117 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+
+import type { Event, EventSegment, PaginatedResult, Pagination } from '@covenant-connect/shared';
+
+type CreateEventInput = {
+  title: string;
+  description?: string;
+  startsAt: Date;
+  endsAt: Date;
+  timezone: string;
+  recurrenceRule?: string;
+  tags?: string[];
+  location: string;
+  segments?: Omit<EventSegment, 'id'>[];
+};
+
+type UpdateEventInput = Partial<CreateEventInput>;
+
+@Injectable()
+export class EventsService {
+  private readonly events = new Map<string, Event>();
+
+  async create(input: CreateEventInput): Promise<Event> {
+    const now = new Date();
+    const segments: EventSegment[] = (input.segments ?? []).map((segment) => ({
+      ...segment,
+      id: randomUUID()
+    }));
+
+    const event: Event = {
+      id: randomUUID(),
+      title: input.title,
+      description: input.description,
+      startsAt: input.startsAt,
+      endsAt: input.endsAt,
+      timezone: input.timezone,
+      recurrenceRule: input.recurrenceRule,
+      segments,
+      tags: input.tags ?? [],
+      location: input.location,
+      createdAt: now,
+      updatedAt: now
+    };
+
+    this.events.set(event.id, event);
+    return event;
+  }
+
+  async list(pagination: Pagination): Promise<PaginatedResult<Event>> {
+    const data = Array.from(this.events.values()).sort(
+      (left, right) => left.startsAt.getTime() - right.startsAt.getTime()
+    );
+
+    const start = (pagination.page - 1) * pagination.pageSize;
+    const end = start + pagination.pageSize;
+
+    return {
+      data: data.slice(start, end),
+      total: data.length,
+      page: pagination.page,
+      pageSize: pagination.pageSize
+    };
+  }
+
+  async update(eventId: string, input: UpdateEventInput): Promise<Event> {
+    const existing = this.events.get(eventId);
+    if (!existing) {
+      throw new NotFoundException('Event not found');
+    }
+
+    const segments = input.segments
+      ? input.segments.map((segment) => ({
+          ...segment,
+          id: segment.id ?? randomUUID()
+        }))
+      : existing.segments;
+
+    const updated: Event = {
+      ...existing,
+      ...input,
+      segments,
+      tags: input.tags ?? existing.tags,
+      updatedAt: new Date()
+    };
+
+    this.events.set(updated.id, updated);
+    return updated;
+  }
+
+  async toICalendar(): Promise<string> {
+    const lines = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//Covenant Connect//EN'
+    ];
+
+    for (const event of this.events.values()) {
+      lines.push('BEGIN:VEVENT');
+      lines.push(`UID:${event.id}`);
+      lines.push(`SUMMARY:${event.title}`);
+      if (event.description) {
+        lines.push(`DESCRIPTION:${event.description}`);
+      }
+      lines.push(`DTSTART:${event.startsAt.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')}`);
+      lines.push(`DTEND:${event.endsAt.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')}`);
+      lines.push(`LOCATION:${event.location}`);
+      if (event.recurrenceRule) {
+        lines.push(`RRULE:${event.recurrenceRule}`);
+      }
+      lines.push('END:VEVENT');
+    }
+
+    lines.push('END:VCALENDAR');
+    return lines.join('\n');
+  }
+}

--- a/apps/backend/src/modules/health/health.controller.ts
+++ b/apps/backend/src/modules/health/health.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get } from '@nestjs/common';
+import {
+  HealthCheck,
+  HealthCheckResult,
+  HealthCheckService
+} from '@nestjs/terminus';
+
+import { HealthIndicatorService } from './health.indicator';
+
+@Controller('health')
+export class HealthController {
+  constructor(
+    private readonly health: HealthCheckService,
+    private readonly indicatorService: HealthIndicatorService
+  ) {}
+
+  @Get('live')
+  @HealthCheck()
+  checkLiveness(): Promise<HealthCheckResult> {
+    return this.health.check([this.indicatorService.isAlive]);
+  }
+
+  @Get('ready')
+  @HealthCheck()
+  checkReadiness(): Promise<HealthCheckResult> {
+    return this.health.check([this.indicatorService.isReady]);
+  }
+}

--- a/apps/backend/src/modules/health/health.indicator.ts
+++ b/apps/backend/src/modules/health/health.indicator.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { HealthIndicator, HealthIndicatorFunction } from '@nestjs/terminus';
+
+@Injectable()
+export class HealthIndicatorService extends HealthIndicator {
+  isAlive: HealthIndicatorFunction = async () => {
+    return this.getStatus('api', true);
+  };
+
+  isReady: HealthIndicatorFunction = async () => {
+    // TODO: add datastore and queue probes when wiring infrastructure.
+    return this.getStatus('dependencies', true);
+  };
+}

--- a/apps/backend/src/modules/health/health.module.ts
+++ b/apps/backend/src/modules/health/health.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TerminusModule } from '@nestjs/terminus';
+
+import { HealthController } from './health.controller';
+import { HealthIndicatorService } from './health.indicator';
+
+@Module({
+  imports: [TerminusModule],
+  controllers: [HealthController],
+  providers: [HealthIndicatorService]
+})
+export class HealthModule {}

--- a/apps/backend/src/modules/integrations/integrations.controller.ts
+++ b/apps/backend/src/modules/integrations/integrations.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Get, Put } from '@nestjs/common';
+
+import type { IntegrationSettings } from '@covenant-connect/shared';
+
+import { IntegrationsService } from './integrations.service';
+
+@Controller('integrations')
+export class IntegrationsController {
+  constructor(private readonly integrations: IntegrationsService) {}
+
+  @Get()
+  get(): Promise<IntegrationSettings> {
+    return this.integrations.get();
+  }
+
+  @Put()
+  update(@Body() body: IntegrationSettings): Promise<IntegrationSettings> {
+    return this.integrations.update(body);
+  }
+}

--- a/apps/backend/src/modules/integrations/integrations.module.ts
+++ b/apps/backend/src/modules/integrations/integrations.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { IntegrationsController } from './integrations.controller';
+import { IntegrationsService } from './integrations.service';
+
+@Module({
+  controllers: [IntegrationsController],
+  providers: [IntegrationsService],
+  exports: [IntegrationsService]
+})
+export class IntegrationsModule {}

--- a/apps/backend/src/modules/integrations/integrations.service.ts
+++ b/apps/backend/src/modules/integrations/integrations.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+
+import type { IntegrationSettings } from '@covenant-connect/shared';
+
+@Injectable()
+export class IntegrationsService {
+  private settings: IntegrationSettings = {};
+
+  async get(): Promise<IntegrationSettings> {
+    return this.settings;
+  }
+
+  async update(settings: IntegrationSettings): Promise<IntegrationSettings> {
+    this.settings = { ...this.settings, ...settings };
+    return this.settings;
+  }
+}

--- a/apps/backend/src/modules/prayer/prayer.controller.ts
+++ b/apps/backend/src/modules/prayer/prayer.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+
+import type { PaginatedResult, PrayerRequest } from '@covenant-connect/shared';
+
+import { PrayerService } from './prayer.service';
+
+@Controller('prayer')
+export class PrayerController {
+  constructor(private readonly prayer: PrayerService) {}
+
+  @Post('requests')
+  create(
+    @Body()
+    body: { requesterName: string; message: string; requesterEmail?: string; requesterPhone?: string; memberId?: string }
+  ): Promise<PrayerRequest> {
+    return this.prayer.create(body);
+  }
+
+  @Get('requests')
+  list(): Promise<PaginatedResult<PrayerRequest>> {
+    return this.prayer.list();
+  }
+
+  @Patch('requests/:id')
+  update(
+    @Param('id') id: string,
+    @Body() body: Partial<Pick<PrayerRequest, 'status' | 'followUpAt'>>
+  ): Promise<PrayerRequest> {
+    return this.prayer.update(id, body);
+  }
+}

--- a/apps/backend/src/modules/prayer/prayer.module.ts
+++ b/apps/backend/src/modules/prayer/prayer.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { PrayerController } from './prayer.controller';
+import { PrayerService } from './prayer.service';
+
+@Module({
+  controllers: [PrayerController],
+  providers: [PrayerService],
+  exports: [PrayerService]
+})
+export class PrayerModule {}

--- a/apps/backend/src/modules/prayer/prayer.service.ts
+++ b/apps/backend/src/modules/prayer/prayer.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+
+import type { PaginatedResult, PrayerRequest } from '@covenant-connect/shared';
+
+type CreatePrayerRequestInput = {
+  requesterName: string;
+  requesterEmail?: string;
+  requesterPhone?: string;
+  message: string;
+  memberId?: string;
+};
+
+type UpdatePrayerRequestInput = Partial<Pick<PrayerRequest, 'status' | 'followUpAt'>>;
+
+@Injectable()
+export class PrayerService {
+  private readonly requests = new Map<string, PrayerRequest>();
+
+  async create(input: CreatePrayerRequestInput): Promise<PrayerRequest> {
+    const now = new Date();
+    const request: PrayerRequest = {
+      id: randomUUID(),
+      requesterName: input.requesterName,
+      requesterEmail: input.requesterEmail,
+      requesterPhone: input.requesterPhone,
+      message: input.message,
+      memberId: input.memberId,
+      status: 'new',
+      createdAt: now,
+      updatedAt: now
+    };
+
+    this.requests.set(request.id, request);
+    return request;
+  }
+
+  async list(): Promise<PaginatedResult<PrayerRequest>> {
+    const data = Array.from(this.requests.values());
+    return {
+      data,
+      total: data.length,
+      page: 1,
+      pageSize: data.length || 1
+    };
+  }
+
+  async update(requestId: string, input: UpdatePrayerRequestInput): Promise<PrayerRequest> {
+    const existing = this.requests.get(requestId);
+    if (!existing) {
+      throw new NotFoundException('Prayer request not found');
+    }
+
+    const updated: PrayerRequest = {
+      ...existing,
+      ...input,
+      updatedAt: new Date()
+    };
+
+    this.requests.set(updated.id, updated);
+    return updated;
+  }
+}

--- a/apps/backend/src/modules/reports/reports.controller.ts
+++ b/apps/backend/src/modules/reports/reports.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+
+import { ReportsService } from './reports.service';
+
+@Controller('reports')
+export class ReportsController {
+  constructor(private readonly reports: ReportsService) {}
+
+  @Get('dashboard')
+  dashboard(): Promise<{ kpis: { label: string; value: number; change?: number }[] }> {
+    return this.reports.getDashboard();
+  }
+}

--- a/apps/backend/src/modules/reports/reports.module.ts
+++ b/apps/backend/src/modules/reports/reports.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { DonationsModule } from '../donations/donations.module';
+import { EventsModule } from '../events/events.module';
+import { PrayerModule } from '../prayer/prayer.module';
+import { ReportsController } from './reports.controller';
+import { ReportsService } from './reports.service';
+
+@Module({
+  imports: [DonationsModule, EventsModule, PrayerModule],
+  controllers: [ReportsController],
+  providers: [ReportsService]
+})
+export class ReportsModule {}

--- a/apps/backend/src/modules/reports/reports.service.ts
+++ b/apps/backend/src/modules/reports/reports.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+
+import type { DashboardKpi } from '@covenant-connect/shared';
+
+import { DonationsService } from '../donations/donations.service';
+import { EventsService } from '../events/events.service';
+import { PrayerService } from '../prayer/prayer.service';
+
+@Injectable()
+export class ReportsService {
+  constructor(
+    private readonly donations: DonationsService,
+    private readonly prayer: PrayerService,
+    private readonly events: EventsService
+  ) {}
+
+  async getDashboard(): Promise<{ kpis: DashboardKpi[] }> {
+    const donationsList = await this.donations.list({ page: 1, pageSize: 100 });
+    const upcomingEvents = await this.events.list({ page: 1, pageSize: 50 });
+    const prayerRequests = await this.prayer.list();
+
+    const totalGiving = donationsList.data.reduce((sum, donation) => sum + donation.amount, 0);
+    const completedDonations = donationsList.data.filter((donation) => donation.status === 'completed');
+
+    const kpis: DashboardKpi[] = [
+      { label: 'Total Giving', value: totalGiving },
+      { label: 'Completed Donations', value: completedDonations.length },
+      { label: 'Upcoming Events', value: upcomingEvents.data.length },
+      { label: 'Open Prayer Requests', value: prayerRequests.data.filter((req) => req.status !== 'answered').length }
+    ];
+
+    return { kpis };
+  }
+}

--- a/apps/backend/src/modules/tasks/tasks.controller.ts
+++ b/apps/backend/src/modules/tasks/tasks.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+
+import type { QueueJob } from '@covenant-connect/shared';
+
+import { TasksService } from './tasks.service';
+
+@Controller('tasks')
+export class TasksController {
+  constructor(private readonly tasks: TasksService) {}
+
+  @Get()
+  list(): Promise<QueueJob[]> {
+    return this.tasks.list();
+  }
+
+  @Post()
+  enqueue(@Body() body: { name: string; payload: Record<string, unknown> }): Promise<QueueJob> {
+    return this.tasks.enqueue(body.name, body.payload);
+  }
+}

--- a/apps/backend/src/modules/tasks/tasks.module.ts
+++ b/apps/backend/src/modules/tasks/tasks.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { TasksController } from './tasks.controller';
+import { TasksService } from './tasks.service';
+
+@Module({
+  controllers: [TasksController],
+  providers: [TasksService],
+  exports: [TasksService]
+})
+export class TasksModule {}

--- a/apps/backend/src/modules/tasks/tasks.service.ts
+++ b/apps/backend/src/modules/tasks/tasks.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+
+import type { QueueJob } from '@covenant-connect/shared';
+
+@Injectable()
+export class TasksService {
+  private readonly jobs: QueueJob[] = [];
+
+  async enqueue(name: string, payload: Record<string, unknown>): Promise<QueueJob> {
+    const job: QueueJob = {
+      id: randomUUID(),
+      name,
+      payload,
+      scheduledAt: new Date()
+    };
+
+    this.jobs.push(job);
+    return job;
+  }
+
+  async list(): Promise<QueueJob[]> {
+    return this.jobs;
+  }
+}

--- a/apps/backend/tsconfig.build.json
+++ b/apps/backend/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "sourceMap": true
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": "./src",
+    "paths": {
+      "@covenant-connect/shared/*": ["../../packages/shared/src/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/frontend/.eslintrc.json
+++ b/apps/frontend/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next", "next/core-web-vitals"],
+  "rules": {
+    "react/jsx-curly-brace-presence": "off"
+  }
+}

--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { getDashboardReport } from '../../lib/api';
+
+type DashboardResponse = {
+  kpis: { label: string; value: number; change?: number }[];
+};
+
+export default async function DashboardPage() {
+  const report: DashboardResponse = await getDashboardReport().catch(() => ({
+    kpis: [
+      { label: 'Total Giving', value: 0 },
+      { label: 'Completed Donations', value: 0 },
+      { label: 'Upcoming Events', value: 0 }
+    ]
+  }));
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-6 py-12">
+      <header>
+        <h1 className="text-3xl font-semibold text-slate-900">Operational dashboard</h1>
+        <p className="mt-2 text-sm text-slate-500">
+          Monitor the health of your ministry, giving pipeline, and pastoral care automations.
+        </p>
+      </header>
+
+      <section className="grid gap-6 md:grid-cols-3">
+        {report.kpis.map((kpi) => (
+          <article key={kpi.label} className="rounded-2xl border border-slate-100 bg-white p-6 shadow-sm">
+            <p className="text-xs uppercase tracking-wide text-slate-400">{kpi.label}</p>
+            <p className="mt-4 text-3xl font-semibold text-slate-900">{kpi.value}</p>
+            {typeof kpi.change === 'number' ? (
+              <p className="mt-2 text-sm text-emerald-600">{kpi.change.toFixed(1)}% change</p>
+            ) : (
+              <p className="mt-2 text-sm text-slate-400">Awaiting data</p>
+            )}
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -1,0 +1,34 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background-color: rgb(248 250 252);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: inherit;
+}
+
+main {
+  min-height: 100vh;
+}

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import React from 'react';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'Covenant Connect',
+  description: 'A modern ministry platform reimagined in TypeScript.'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={`${inter.className} bg-slate-50 text-slate-900`}>{children}</body>
+    </html>
+  );
+}

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+
+import { getDashboardReport, getHomeContent, getUpcomingEvents } from '../lib/api';
+
+type DashboardResponse = {
+  kpis: { label: string; value: number; change?: number }[];
+};
+
+type EventsResponse = {
+  data: { id: string; title: string; startsAt: string; location: string }[];
+};
+
+type HomeContentResponse = {
+  heroTitle: string;
+  heroSubtitle: string;
+  highlights: string[];
+  nextSteps: { label: string; url: string }[];
+};
+
+async function loadData() {
+  try {
+    const [home, report, events] = await Promise.all<[
+      HomeContentResponse,
+      DashboardResponse,
+      EventsResponse
+    ]>([getHomeContent(), getDashboardReport(), getUpcomingEvents()]);
+
+    return { home, report, events };
+  } catch (error) {
+    console.error('Failed to reach API, falling back to placeholder data.', error);
+    return {
+      home: {
+        heroTitle: 'Plan services and care pathways with ease',
+        heroSubtitle:
+          'The TypeScript rewrite ships with modular services for worship planning, assimilation, and giving.',
+        highlights: [],
+        nextSteps: [
+          { label: 'Launch admin console', url: '/dashboard' },
+          { label: 'Review API docs', url: '/docs' }
+        ]
+      },
+      report: {
+        kpis: [
+          { label: 'Total Giving', value: 0 },
+          { label: 'Completed Donations', value: 0 },
+          { label: 'Upcoming Events', value: 0 }
+        ]
+      },
+      events: {
+        data: []
+      }
+    } satisfies {
+      home: HomeContentResponse;
+      report: DashboardResponse;
+      events: EventsResponse;
+    };
+  }
+}
+
+export default async function HomePage() {
+  const { home, report, events } = await loadData();
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-12">
+      <section className="rounded-3xl bg-gradient-to-br from-indigo-600 via-purple-600 to-blue-600 p-10 text-white shadow-xl">
+        <p className="text-sm uppercase tracking-widest text-indigo-200">Covenant Connect</p>
+        <h1 className="mt-4 text-4xl font-semibold leading-tight md:text-5xl">{home.heroTitle}</h1>
+        <p className="mt-4 max-w-2xl text-lg text-indigo-100">{home.heroSubtitle}</p>
+        {home.highlights?.length ? (
+          <ul className="mt-6 grid gap-2 text-sm text-indigo-100 md:grid-cols-2">
+            {home.highlights.map((item) => (
+              <li key={item} className="flex items-center gap-2">
+                <span aria-hidden className="inline-flex h-2 w-2 rounded-full bg-indigo-200" />
+                {item}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        <div className="mt-8 flex flex-wrap gap-4">
+          {home.nextSteps.map((step) => (
+            <a
+              key={step.url}
+              className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium backdrop-blur transition hover:bg-white/20"
+              href={step.url}
+            >
+              {step.label}
+            </a>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-3">
+        {report.kpis.map((kpi) => (
+          <article key={kpi.label} className="rounded-2xl bg-white p-6 shadow-sm">
+            <p className="text-sm font-medium text-slate-500">{kpi.label}</p>
+            <p className="mt-3 text-3xl font-semibold text-slate-900">
+              {kpi.value.toLocaleString('en-US', { maximumFractionDigits: 2 })}
+            </p>
+            {typeof kpi.change === 'number' ? (
+              <p className="mt-2 text-sm text-emerald-600">{kpi.change.toFixed(1)}% vs. last period</p>
+            ) : null}
+          </article>
+        ))}
+      </section>
+
+      <section className="rounded-2xl bg-white p-6 shadow-sm">
+        <header className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-slate-900">Upcoming gatherings</h2>
+          <a className="text-sm font-medium text-indigo-600" href="/events">
+            View all
+          </a>
+        </header>
+        <ul className="mt-6 space-y-4">
+          {events.data.map((event) => (
+            <li key={event.id} className="flex items-center justify-between rounded-xl border border-slate-100 p-4">
+              <div>
+                <p className="text-sm font-medium text-slate-500">
+                  {new Date(event.startsAt).toLocaleDateString(undefined, {
+                    weekday: 'short',
+                    month: 'short',
+                    day: 'numeric'
+                  })}
+                </p>
+                <p className="text-lg font-semibold text-slate-900">{event.title}</p>
+                <p className="text-sm text-slate-500">{event.location}</p>
+              </div>
+              <button className="rounded-full border border-indigo-200 px-4 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-50">
+                Manage
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/apps/frontend/next-env.d.ts
+++ b/apps/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@covenant-connect/frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "next": "^13.5.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.9.0",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.53.0",
+    "eslint-config-next": "^13.5.6",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.2.2",
+    "vitest": "^0.34.5"
+  }
+}

--- a/apps/frontend/postcss.config.js
+++ b/apps/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'sans-serif']
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "incremental": true,
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docs/js-architecture.md
+++ b/docs/js-architecture.md
@@ -1,0 +1,79 @@
+# Covenant Connect TypeScript Architecture
+
+This document captures the initial structure for the JavaScript/TypeScript rewrite of Covenant Connect. It highlights the technology choices, module layout, and the plan for expanding feature parity with the Python/Flask implementation.
+
+## Technology stack
+
+| Area      | Selection | Rationale |
+|-----------|-----------|-----------|
+| Backend   | [NestJS](https://nestjs.com/) on Node 18+ | Decorator-driven modules mirror Flask blueprints, dependency injection keeps the code modular, and the ecosystem integrates well with Prisma, class-validator, and BullMQ. |
+| ORM       | Prisma (planned) | Prisma offers schema-first modelling with type-safe client generation. The current code ships with an in-memory repository layer that can be swapped for Prisma once the schema migration is authored. |
+| Auth      | argon2 password hashing + pluggable OAuth handlers | Mirrors the existing local login and social sign-in flows while allowing future provider-specific strategies. |
+| Queue     | BullMQ/Redis (planned) | The in-memory task queue abstracts the interface required for follow-up scheduling, making it simple to drop in BullMQ workers later. |
+| Frontend  | Next.js 13 app router + Tailwind CSS | Provides hybrid SSG/SSR for marketing pages and authenticated dashboards, while Tailwind accelerates UI delivery. |
+| Shared    | TypeScript workspace package | Domain types are colocated in `packages/shared` so both the backend and frontend consume a single source of truth for entities such as `UserAccount`, `Donation`, and `Event`. |
+
+## Monorepo layout
+
+```
+.
+├── package.json            # npm workspaces orchestrating backend, frontend, shared
+├── tsconfig.base.json      # Compiler defaults shared across packages
+├── apps
+│   ├── backend             # NestJS API
+│   └── frontend            # Next.js web experience
+└── packages
+    └── shared              # Domain interfaces shared across the stack
+```
+
+### Backend structure
+
+```
+apps/backend
+├── src
+│   ├── main.ts             # Nest bootstrap, CORS, helmet
+│   ├── app.module.ts       # Global module wiring
+│   ├── config/             # Environment-backed configuration slices
+│   └── modules/
+│       ├── accounts/       # Account repository + service
+│       ├── auth/           # Login, registration, social providers, session store
+│       ├── churches/       # Church profile CRUD
+│       ├── content/        # Sermons & homepage content APIs
+│       ├── donations/      # Multi-gateway donation orchestration
+│       ├── email/          # Provider management + dispatch façade
+│       ├── events/         # Event planning + ICS feeds
+│       ├── health/         # Terminus-powered health checks
+│       ├── integrations/   # Payment/email integration settings
+│       ├── prayer/         # Prayer intake & follow-up metadata
+│       ├── reports/        # Aggregate KPI reporting
+│       └── tasks/          # Background job queue abstraction
+```
+
+Each module exposes a Nest `Module`, `Service`, and (where relevant) `Controller`. Today the services rely on in-memory stores to keep the initial commit lightweight; the method contracts align with Prisma models so the repository layer can swap to a real database with minimal churn.
+
+### Frontend structure
+
+```
+apps/frontend
+├── app/                    # Next.js app router routes
+│   ├── layout.tsx          # Global shell + font loading
+│   ├── page.tsx            # Marketing landing page with SSR data fetch
+│   └── dashboard/page.tsx  # Staff dashboard view
+├── lib/api.ts              # Thin typed fetch wrappers for backend endpoints
+├── tailwind.config.ts      # Tailwind design tokens
+├── postcss.config.js       # Tailwind + autoprefixer pipeline
+└── app/globals.css         # Tailwind entry point + base styles
+```
+
+All data fetching uses the shared API client which reads `NEXT_PUBLIC_API_BASE_URL`. When the backend is unavailable the UI falls back to placeholder content so the experience degrades gracefully during local development.
+
+## Follow-up work
+
+1. **Database schema migration** – Translate the SQLAlchemy models into Prisma schema and generate the client. Replace the in-memory repositories in `accounts`, `donations`, `events`, etc. with Prisma-backed services.
+2. **OAuth provider integration** – Implement Google, Facebook, and Apple strategies using Passport or direct OAuth clients, persisting tokens and refresh workflows.
+3. **Payment gateways** – Replace the mock donation lifecycle with concrete SDK integrations for Paystack, Fincra, Stripe, and Flutterwave plus webhook verification endpoints.
+4. **Queue infrastructure** – Connect the tasks module to Redis-backed BullMQ workers and port scheduled jobs (KPI digests, follow-ups, automation runners).
+5. **Testing & CI** – Introduce Vitest/Jest suites that mirror the Python pytest coverage and configure GitHub Actions for linting, type-checking, and tests across the monorepo.
+6. **Deployment scripts** – Author Dockerfiles and Terraform/Helm manifests for the Node services, aligning with the deployment practices documented in `docs/deployment-runbook.md`.
+
+This scaffold provides a production-ready foundation while leaving room to iteratively port the remaining domain logic from the Flask application.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "covenant-connect-js",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "apps/backend",
+    "apps/frontend",
+    "packages/shared"
+  ],
+  "scripts": {
+    "build": "npm run build --workspaces",
+    "dev": "npm run dev -w apps/backend",
+    "lint": "npm run lint --workspaces",
+    "test": "npm run test --workspaces"
+  }
+}

--- a/packages/shared/.eslintrc.cjs
+++ b/packages/shared/.eslintrc.cjs
@@ -1,0 +1,25 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true
+  },
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'import'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
+    'prettier'
+  ],
+  rules: {
+    'import/order': [
+      'error',
+      {
+        groups: [['builtin', 'external'], 'internal', ['parent', 'sibling', 'index']],
+        'newlines-between': 'always'
+      }
+    ],
+    '@typescript-eslint/explicit-module-boundary-types': 'off'
+  }
+};

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@covenant-connect/shared",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint --ext .ts src",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^20.9.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.5",
+    "@typescript-eslint/parser": "^6.7.5",
+    "eslint": "^8.53.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-import": "^2.29.0",
+    "prettier": "^3.0.3",
+    "typescript": "^5.2.2",
+    "vitest": "^0.34.5"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,203 @@
+export type Provider = 'google' | 'facebook' | 'apple' | 'password';
+
+export type UserAccount = {
+  id: string;
+  email: string;
+  passwordHash?: string;
+  firstName: string;
+  lastName: string;
+  avatarUrl?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  roles: string[];
+  providers: ProviderIdentity[];
+};
+
+export type ProviderIdentity = {
+  provider: Provider;
+  providerId: string;
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: Date | null;
+};
+
+export type MemberProfile = {
+  id: string;
+  userId: string;
+  phone?: string;
+  address?: string;
+  dateOfBirth?: string;
+  gender?: 'male' | 'female' | 'unspecified';
+  nextSteps: string[];
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type Donation = {
+  id: string;
+  memberId: string | null;
+  amount: number;
+  currency: string;
+  provider: 'paystack' | 'fincra' | 'stripe' | 'flutterwave';
+  status: 'pending' | 'completed' | 'failed' | 'refunded';
+  metadata: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type EventSegment = {
+  id: string;
+  name: string;
+  startOffsetMinutes: number;
+  durationMinutes: number;
+  ownerId: string | null;
+};
+
+export type Event = {
+  id: string;
+  title: string;
+  description?: string;
+  startsAt: Date;
+  endsAt: Date;
+  timezone: string;
+  recurrenceRule?: string;
+  segments: EventSegment[];
+  tags: string[];
+  location: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type PrayerRequest = {
+  id: string;
+  requesterName: string;
+  requesterEmail?: string;
+  requesterPhone?: string;
+  message: string;
+  memberId?: string;
+  status: 'new' | 'assigned' | 'praying' | 'answered';
+  followUpAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type Automation = {
+  id: string;
+  name: string;
+  trigger: string;
+  isActive: boolean;
+  steps: AutomationStep[];
+};
+
+export type AutomationStep = {
+  id: string;
+  type: 'email' | 'sms' | 'task' | 'webhook';
+  configuration: Record<string, unknown>;
+  delaySeconds: number;
+};
+
+export type EmailProviderType = 'ses' | 'mailgun' | 'smtp';
+
+export type EmailProvider = {
+  id: string;
+  type: EmailProviderType;
+  name: string;
+  credentials: Record<string, string>;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type DashboardKpi = {
+  label: string;
+  value: number;
+  change?: number;
+};
+
+export type Sermon = {
+  id: string;
+  title: string;
+  speaker: string;
+  description?: string;
+  mediaUrl?: string;
+  recordedAt?: Date;
+};
+
+export type HomeContent = {
+  heroTitle: string;
+  heroSubtitle: string;
+  highlights: string[];
+  nextSteps: { label: string; url: string }[];
+};
+
+export type VolunteerAssignment = {
+  id: string;
+  eventId: string;
+  memberId: string;
+  role: string;
+  status: 'confirmed' | 'pending' | 'declined';
+};
+
+export type IntegrationSettings = {
+  paystack?: Record<string, string>;
+  fincra?: Record<string, string>;
+  stripe?: Record<string, string>;
+  flutterwave?: Record<string, string>;
+};
+
+export type Church = {
+  id: string;
+  name: string;
+  timezone: string;
+  country?: string;
+  state?: string;
+  city?: string;
+  settings: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type NotificationPreference = {
+  memberId: string;
+  email: boolean;
+  sms: boolean;
+  push: boolean;
+};
+
+export type Pagination = {
+  page: number;
+  pageSize: number;
+};
+
+export type PaginatedResult<T> = {
+  data: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export type DateRange = {
+  start: Date;
+  end: Date;
+};
+
+export type SearchQuery = {
+  term?: string;
+  tags?: string[];
+  dateRange?: DateRange;
+};
+
+export type Attachment = {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  url: string;
+};
+
+export type QueueJob = {
+  id: string;
+  name: string;
+  payload: Record<string, unknown>;
+  scheduledAt: Date;
+};

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "rootDir": "./",
+    "baseUrl": "./",
+    "resolveJsonModule": true,
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
## Summary
- add a Node/NestJS backend skeleton that mirrors the major Flask services with modular controllers and services
- scaffold a Next.js frontend with Tailwind styling and shared API client helpers
- introduce a shared TypeScript workspace for domain types plus architecture documentation outlining the JS rewrite

## Testing
- pytest *(fails: missing flask_migrate dependency in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf8870bec833384f8514bb716fcc0