### PR TITLE
feat(frontend): add api client for nest backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!apps/frontend/lib/
+!apps/frontend/lib/**
 lib64/
 parts/
 sdist/

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -23,7 +23,7 @@
     "cookie-parser": "^1.4.6",
     "express-session": "^1.17.3",
     "helmet": "^7.0.0",
-    "nestjs-prisma": "^3.1.0",
+    "nestjs-prisma": "^0.25.0",
     "pino": "^8.15.0",
     "pino-pretty": "^10.2.0",
     "reflect-metadata": "^0.1.13",

--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 
+import type { DashboardResponse } from '../../lib/api';
 import { getDashboardReport } from '../../lib/api';
-
-type DashboardResponse = {
-  kpis: { label: string; value: number; change?: number }[];
-};
 
 export default async function DashboardPage() {
   const report: DashboardResponse = await getDashboardReport().catch(() => ({

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -1,21 +1,7 @@
 import React from 'react';
 
+import type { DashboardResponse, EventsResponse, HomeContentResponse } from '../lib/api';
 import { getDashboardReport, getHomeContent, getUpcomingEvents } from '../lib/api';
-
-type DashboardResponse = {
-  kpis: { label: string; value: number; change?: number }[];
-};
-
-type EventsResponse = {
-  data: { id: string; title: string; startsAt: string; location: string }[];
-};
-
-type HomeContentResponse = {
-  heroTitle: string;
-  heroSubtitle: string;
-  highlights: string[];
-  nextSteps: { label: string; url: string }[];
-};
 
 async function loadData() {
   try {
@@ -47,7 +33,10 @@ async function loadData() {
         ]
       },
       events: {
-        data: []
+        data: [],
+        total: 0,
+        page: 1,
+        pageSize: 0
       }
     } satisfies {
       home: HomeContentResponse;

--- a/apps/frontend/lib/api.ts
+++ b/apps/frontend/lib/api.ts
@@ -1,0 +1,109 @@
+const ensureLeadingSlash = (path: string): string => (path.startsWith('/') ? path : `/${path}`);
+
+const normalizeBaseUrl = (input: string | undefined): string => {
+  const trimmed = input?.trim();
+  if (!trimmed) {
+    return 'http://localhost:8000';
+  }
+
+  return trimmed.replace(/\/$/, '');
+};
+
+const API_BASE_URL = normalizeBaseUrl(process.env.NEXT_PUBLIC_API_BASE_URL);
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly detail?: unknown
+  ) {
+    super(
+      detail
+        ? `API request failed with status ${status} ${statusText}: ${
+            typeof detail === 'string' ? detail : JSON.stringify(detail)
+          }`
+        : `API request failed with status ${status} ${statusText}`
+    );
+    this.name = 'ApiError';
+  }
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${ensureLeadingSlash(path)}`, {
+    ...init,
+    headers: {
+      Accept: 'application/json',
+      ...(init.headers ?? {})
+    },
+    cache: init.cache ?? 'no-store'
+  });
+
+  const rawBody = await response.text();
+  let data: unknown = rawBody.length ? rawBody : null;
+
+  if (rawBody.length) {
+    try {
+      data = JSON.parse(rawBody);
+    } catch (error) {
+      // Non-JSON payloads fall back to the raw string response.
+    }
+  }
+
+  if (!response.ok) {
+    throw new ApiError(response.status, response.statusText, data ?? undefined);
+  }
+
+  return data as T;
+}
+
+export type DashboardKpi = {
+  label: string;
+  value: number;
+  change?: number;
+};
+
+export type DashboardResponse = {
+  kpis: DashboardKpi[];
+};
+
+export type HomeContentResponse = {
+  heroTitle: string;
+  heroSubtitle: string;
+  highlights: string[];
+  nextSteps: { label: string; url: string }[];
+};
+
+export type PaginatedResponse<T> = {
+  data: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export type EventSummary = {
+  id: string;
+  title: string;
+  startsAt: string;
+  endsAt: string;
+  timezone: string;
+  location: string;
+  recurrenceRule?: string;
+  tags?: string[];
+};
+
+export type EventsResponse = PaginatedResponse<EventSummary>;
+
+export async function getDashboardReport(): Promise<DashboardResponse> {
+  return request<DashboardResponse>('/reports/dashboard');
+}
+
+export async function getHomeContent(): Promise<HomeContentResponse> {
+  return request<HomeContentResponse>('/content/home');
+}
+
+export async function getUpcomingEvents(limit = 3): Promise<EventsResponse> {
+  const search = new URLSearchParams({ page: '1', pageSize: String(limit) });
+  return request<EventsResponse>(`/events?${search.toString()}`);
+}
+
+export { API_BASE_URL };

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -2,13 +2,30 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "noEmit": true,
     "incremental": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "isolatedModules": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add a typed API helper so the Next.js app can call the Nest backend endpoints
- reuse the shared client on the landing and dashboard pages while keeping fallback data in sync with the paginated response shape
- allow committing the new lib directory and fix the nestjs-prisma dependency so `npm install` succeeds

## Testing
- npm run lint -w apps/frontend
- npm run lint -w apps/backend *(fails: pre-existing import ordering and unused variable lint errors in the Nest project)*

------
https://chatgpt.com/codex/tasks/task_e_68cf262c89e483338d0dc750c2d639f8