### PR TITLE
feat: integrate OAuth providers and tests

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -26,6 +26,7 @@
     "cookie-parser": "^1.4.6",
     "express-session": "^1.17.3",
     "helmet": "^7.0.0",
+    "jose": "^5.2.4",
     "nestjs-prisma": "^0.25.0",
     "pino": "^8.15.0",
     "pino-pretty": "^10.2.0",

--- a/apps/backend/src/config/configuration.ts
+++ b/apps/backend/src/config/configuration.ts
@@ -18,6 +18,7 @@ type IntegrationsConfig = {
   googleClientSecret: string | null;
   facebookClientId: string | null;
   facebookClientSecret: string | null;
+  appleClientId: string | null;
   appleTeamId: string | null;
   appleKeyId: string | null;
   applePrivateKey: string | null;
@@ -73,6 +74,7 @@ export default registerAs<ApplicationConfig>('application', () => ({
     googleClientSecret: process.env.GOOGLE_CLIENT_SECRET ?? null,
     facebookClientId: process.env.FACEBOOK_CLIENT_ID ?? null,
     facebookClientSecret: process.env.FACEBOOK_CLIENT_SECRET ?? null,
+    appleClientId: process.env.APPLE_CLIENT_ID ?? null,
     appleTeamId: process.env.APPLE_TEAM_ID ?? null,
     appleKeyId: process.env.APPLE_KEY_ID ?? null,
     applePrivateKey: process.env.APPLE_PRIVATE_KEY ?? null

--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -46,17 +46,9 @@ export class AuthController {
     @Param('provider') provider: string,
     @Body() body: ProviderCallbackDto
   ): Promise<{ account: UserAccount; session: Session; redirectUri?: string }> {
-    // TODO: Replace with real provider integration that exchanges `code` for a profile.
-    const mockProfile = {
-      providerId: body.code,
-      email: `${body.code}@${provider}.oauth`,
-      firstName: provider.charAt(0).toUpperCase() + provider.slice(1),
-      lastName: 'User'
-    };
-
     return this.authService.completeProviderLogin(
       this.mapProvider(provider),
-      mockProfile,
+      body.code,
       body.state
     );
   }

--- a/apps/backend/src/modules/auth/auth.module.ts
+++ b/apps/backend/src/modules/auth/auth.module.ts
@@ -4,12 +4,33 @@ import { ConfigModule } from '@nestjs/config';
 import { AccountsModule } from '../accounts/accounts.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import {
+  AUTH_PROVIDER_STRATEGIES,
+  AppleOAuthProvider,
+  FacebookOAuthProvider,
+  GoogleOAuthProvider
+} from './providers';
 import { SessionStore } from './session.store';
 
 @Module({
   imports: [ConfigModule, AccountsModule],
   controllers: [AuthController],
-  providers: [AuthService, SessionStore],
+  providers: [
+    AuthService,
+    SessionStore,
+    GoogleOAuthProvider,
+    FacebookOAuthProvider,
+    AppleOAuthProvider,
+    {
+      provide: AUTH_PROVIDER_STRATEGIES,
+      useFactory: (
+        google: GoogleOAuthProvider,
+        facebook: FacebookOAuthProvider,
+        apple: AppleOAuthProvider
+      ) => [google, facebook, apple],
+      inject: [GoogleOAuthProvider, FacebookOAuthProvider, AppleOAuthProvider]
+    }
+  ],
   exports: [AuthService]
 })
 export class AuthModule {}

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -1,9 +1,15 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type { Provider, ProviderIdentity, UserAccount } from '@covenant-connect/shared';
 
 import { AccountsService } from '../accounts/accounts.service';
 import { RegisterDto } from './dto/register.dto';
+import {
+  AUTH_PROVIDER_STRATEGIES,
+  type OAuthExchangeResult,
+  type OAuthProvider,
+  type OAuthProviderStrategy
+} from './providers';
 import { Session, SessionStore } from './session.store';
 
 type LoginResult = {
@@ -11,21 +17,18 @@ type LoginResult = {
   session: Session;
 };
 
-type ProviderProfile = {
-  providerId: string;
-  email: string;
-  firstName: string;
-  lastName: string;
-  avatarUrl?: string;
-};
-
 @Injectable()
 export class AuthService {
+  private readonly providerMap: Map<OAuthProvider, OAuthProviderStrategy>;
+
   constructor(
     private readonly accounts: AccountsService,
     private readonly sessions: SessionStore,
-    private readonly configService: ConfigService
-  ) {}
+    private readonly configService: ConfigService,
+    @Inject(AUTH_PROVIDER_STRATEGIES) providerStrategies: OAuthProviderStrategy[]
+  ) {
+    this.providerMap = new Map(providerStrategies.map((strategy) => [strategy.provider, strategy]));
+  }
 
   async register(payload: RegisterDto): Promise<LoginResult> {
     const account = await this.accounts.createAccount({
@@ -68,9 +71,9 @@ export class AuthService {
     authorizationUrl: string;
     state: string;
   }> {
-    const stateToken = Buffer.from(JSON.stringify({ redirectUri, state })).toString('base64url');
-    const baseUrl = this.providerBaseUrl(provider);
-    const authorizationUrl = `${baseUrl}?state=${stateToken}`;
+    const strategy = this.requireStrategy(provider);
+    const stateToken = this.encodeState(redirectUri, state);
+    const authorizationUrl = strategy.createAuthorizationUrl({ state: stateToken, redirectUri });
 
     return {
       authorizationUrl,
@@ -80,35 +83,43 @@ export class AuthService {
 
   async completeProviderLogin(
     provider: Provider,
-    profile: ProviderProfile,
+    code: string,
     stateToken?: string
   ): Promise<{ account: UserAccount; session: Session; redirectUri?: string }> {
-    let account = await this.accounts.getAccountByProvider(provider, profile.providerId);
+    const strategy = this.requireStrategy(provider);
+    const decodedState = this.decodeState(stateToken);
+    let exchange: OAuthExchangeResult;
+
+    try {
+      exchange = await strategy.exchangeCode({ code, redirectUri: decodedState?.redirectUri });
+    } catch (error) {
+      throw new UnauthorizedException('Failed to authenticate with provider');
+    }
+
+    const identity: ProviderIdentity = {
+      provider,
+      providerId: exchange.providerId,
+      accessToken: exchange.tokens.accessToken,
+      refreshToken: exchange.tokens.refreshToken,
+      expiresAt: exchange.tokens.expiresAt
+    };
+
+    let account = await this.accounts.getAccountByProvider(provider, identity.providerId);
 
     if (!account) {
-      const providerIdentity: ProviderIdentity = {
-        provider,
-        providerId: profile.providerId,
-        accessToken: 'mock-access-token'
-      };
-
       account = await this.accounts.createAccount({
-        email: profile.email,
-        firstName: profile.firstName,
-        lastName: profile.lastName,
-        provider: providerIdentity,
+        email: exchange.email,
+        firstName: exchange.firstName || provider,
+        lastName: exchange.lastName || 'User',
+        provider: identity,
         roles: ['member']
       });
     } else {
-      await this.accounts.linkProvider(account.id, {
-        provider,
-        providerId: profile.providerId,
-        accessToken: 'mock-access-token'
-      });
+      account = await this.accounts.linkProvider(account.id, identity);
     }
 
     const session = await this.issueSession(account.id);
-    const redirectUri = this.extractRedirect(stateToken);
+    const redirectUri = this.resolveRedirect(decodedState?.redirectUri);
 
     return { account, session, redirectUri };
   }
@@ -122,29 +133,48 @@ export class AuthService {
     return this.sessions.create(accountId, ttl);
   }
 
-  private providerBaseUrl(provider: Provider): string {
-    const overrides: Record<Provider, string> = {
-      google: 'https://accounts.google.com/o/oauth2/v2/auth',
-      facebook: 'https://www.facebook.com/v14.0/dialog/oauth',
-      apple: 'https://appleid.apple.com/auth/authorize',
-      password: ''
-    };
+  private requireStrategy(provider: Provider): OAuthProviderStrategy {
+    if (provider === 'password') {
+      throw new UnauthorizedException('Password authentication does not support OAuth flows');
+    }
 
-    return overrides[provider];
+    const strategy = this.providerMap.get(provider as OAuthProvider);
+    if (!strategy) {
+      throw new UnauthorizedException(`Unsupported authentication provider: ${provider}`);
+    }
+
+    return strategy;
   }
 
-  private extractRedirect(stateToken?: string): string | undefined {
+  private encodeState(redirectUri?: string, state?: string): string {
+    return Buffer.from(JSON.stringify({ redirectUri, state })).toString('base64url');
+  }
+
+  private decodeState(stateToken?: string): { redirectUri?: string; state?: string } | undefined {
     if (!stateToken) {
       return undefined;
     }
 
     try {
       const decoded = JSON.parse(Buffer.from(stateToken, 'base64url').toString());
-      const redirectUri: string | undefined = decoded.redirectUri;
-      if (!redirectUri) {
-        return undefined;
+      if (decoded && typeof decoded === 'object') {
+        const redirectUri = typeof decoded.redirectUri === 'string' ? decoded.redirectUri : undefined;
+        const state = typeof decoded.state === 'string' ? decoded.state : undefined;
+        return { redirectUri, state };
       }
+    } catch (error) {
+      return undefined;
+    }
 
+    return undefined;
+  }
+
+  private resolveRedirect(redirectUri?: string): string | undefined {
+    if (!redirectUri) {
+      return undefined;
+    }
+
+    try {
       const allowedOrigins = this.configService.get<string[]>('application.http.cors', []);
       const parsed = new URL(redirectUri);
       if (allowedOrigins.length > 0 && !allowedOrigins.includes(parsed.origin)) {

--- a/apps/backend/src/modules/auth/providers/apple.provider.ts
+++ b/apps/backend/src/modules/auth/providers/apple.provider.ts
@@ -1,0 +1,139 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SignJWT, decodeJwt, importPKCS8 } from 'jose';
+
+import type {
+  AuthorizationUrlParams,
+  CodeExchangeParams,
+  OAuthExchangeResult,
+  OAuthProviderStrategy
+} from './oauth-provider.interface';
+
+const APPLE_TOKEN_URL = 'https://appleid.apple.com/auth/token';
+const APPLE_AUTHORIZE_URL = 'https://appleid.apple.com/auth/authorize';
+const APPLE_AUDIENCE = 'https://appleid.apple.com';
+const APPLE_ALGORITHM = 'ES256';
+
+@Injectable()
+export class AppleOAuthProvider implements OAuthProviderStrategy {
+  readonly provider = 'apple' as const;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  createAuthorizationUrl({ state, redirectUri }: AuthorizationUrlParams): string {
+    const clientId = this.getClientId();
+    const params = new URLSearchParams({
+      response_type: 'code',
+      response_mode: 'form_post',
+      scope: 'name email',
+      client_id: clientId,
+      state
+    });
+
+    if (redirectUri) {
+      params.set('redirect_uri', redirectUri);
+    }
+
+    return `${APPLE_AUTHORIZE_URL}?${params.toString()}`;
+  }
+
+  async exchangeCode({ code, redirectUri }: CodeExchangeParams): Promise<OAuthExchangeResult> {
+    const clientId = this.getClientId();
+    const clientSecret = await this.generateClientSecret(clientId);
+
+    const body = new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      grant_type: 'authorization_code'
+    });
+
+    if (redirectUri) {
+      body.set('redirect_uri', redirectUri);
+    }
+
+    const tokenResponse = await fetch(APPLE_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString()
+    });
+
+    if (!tokenResponse.ok) {
+      throw new Error('Failed to exchange Apple authorization code for tokens');
+    }
+
+    const tokenJson = (await tokenResponse.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      id_token?: string;
+    };
+
+    const accessToken = tokenJson.access_token;
+    if (!accessToken || !tokenJson.id_token) {
+      throw new Error('Apple token response did not contain the expected fields');
+    }
+
+    const payload = decodeJwt(tokenJson.id_token) as {
+      sub?: string;
+      email?: string;
+      given_name?: string;
+      family_name?: string;
+    };
+
+    if (!payload.sub || !payload.email) {
+      throw new Error('Apple identity token did not contain the expected fields');
+    }
+
+    return {
+      provider: this.provider,
+      providerId: payload.sub,
+      email: payload.email,
+      firstName: payload.given_name ?? 'Apple',
+      lastName: payload.family_name ?? 'User',
+      tokens: {
+        accessToken,
+        refreshToken: tokenJson.refresh_token ?? undefined,
+        expiresAt:
+          typeof tokenJson.expires_in === 'number'
+            ? new Date(Date.now() + tokenJson.expires_in * 1000)
+            : undefined
+      }
+    };
+  }
+
+  private getClientId(): string {
+    const clientId = this.configService.get<string>('application.integrations.appleClientId');
+    if (!clientId) {
+      throw new Error('Apple Sign In client ID is not configured');
+    }
+
+    return clientId;
+  }
+
+  private async generateClientSecret(clientId: string): Promise<string> {
+    const teamId = this.configService.get<string>('application.integrations.appleTeamId');
+    const keyId = this.configService.get<string>('application.integrations.appleKeyId');
+    const privateKey = this.configService.get<string>('application.integrations.applePrivateKey');
+
+    if (!teamId || !keyId || !privateKey) {
+      throw new Error('Apple Sign In credentials are not fully configured');
+    }
+
+    const sanitizedKey = (privateKey.includes('-----BEGIN')
+      ? privateKey
+      : privateKey.replace(/\\n/g, '\n'))
+      .trim();
+
+    const key = await importPKCS8(sanitizedKey, APPLE_ALGORITHM);
+
+    return new SignJWT({})
+      .setProtectedHeader({ kid: keyId, alg: APPLE_ALGORITHM })
+      .setIssuer(teamId)
+      .setAudience(APPLE_AUDIENCE)
+      .setSubject(clientId)
+      .setIssuedAt()
+      .setExpirationTime('5m')
+      .sign(key);
+  }
+}

--- a/apps/backend/src/modules/auth/providers/facebook.provider.ts
+++ b/apps/backend/src/modules/auth/providers/facebook.provider.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import type {
+  AuthorizationUrlParams,
+  CodeExchangeParams,
+  OAuthExchangeResult,
+  OAuthProviderStrategy
+} from './oauth-provider.interface';
+
+@Injectable()
+export class FacebookOAuthProvider implements OAuthProviderStrategy {
+  readonly provider = 'facebook' as const;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  createAuthorizationUrl({ state, redirectUri }: AuthorizationUrlParams): string {
+    const clientId = this.getClientId();
+    const params = new URLSearchParams({
+      client_id: clientId,
+      response_type: 'code',
+      scope: 'email,public_profile',
+      state
+    });
+
+    if (redirectUri) {
+      params.set('redirect_uri', redirectUri);
+    }
+
+    return `https://www.facebook.com/v14.0/dialog/oauth?${params.toString()}`;
+  }
+
+  async exchangeCode({ code, redirectUri }: CodeExchangeParams): Promise<OAuthExchangeResult> {
+    const clientId = this.getClientId();
+    const clientSecret = this.getClientSecret();
+
+    const tokenParams = new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code
+    });
+
+    if (redirectUri) {
+      tokenParams.set('redirect_uri', redirectUri);
+    }
+
+    const tokenUrl = `https://graph.facebook.com/v14.0/oauth/access_token?${tokenParams.toString()}`;
+    const tokenResponse = await fetch(tokenUrl, { method: 'GET' });
+
+    if (!tokenResponse.ok) {
+      throw new Error('Failed to exchange Facebook authorization code for tokens');
+    }
+
+    const tokenJson = (await tokenResponse.json()) as {
+      access_token?: string;
+      token_type?: string;
+      expires_in?: number;
+    };
+
+    const accessToken = tokenJson.access_token;
+    if (!accessToken) {
+      throw new Error('Facebook token response did not contain an access token');
+    }
+
+    const profileParams = new URLSearchParams({
+      fields: 'id,email,first_name,last_name,picture',
+      access_token: accessToken
+    });
+
+    const profileUrl = `https://graph.facebook.com/me?${profileParams.toString()}`;
+    const profileResponse = await fetch(profileUrl, { method: 'GET' });
+
+    if (!profileResponse.ok) {
+      throw new Error('Failed to load Facebook profile information');
+    }
+
+    const profileJson = (await profileResponse.json()) as {
+      id?: string;
+      email?: string;
+      first_name?: string;
+      last_name?: string;
+      picture?: { data?: { url?: string } };
+    };
+
+    const providerId = profileJson.id;
+    const email = profileJson.email;
+
+    if (!providerId || !email) {
+      throw new Error('Facebook profile response did not contain the expected fields');
+    }
+
+    return {
+      provider: this.provider,
+      providerId,
+      email,
+      firstName: profileJson.first_name ?? 'Facebook',
+      lastName: profileJson.last_name ?? 'User',
+      avatarUrl: profileJson.picture?.data?.url ?? undefined,
+      tokens: {
+        accessToken,
+        expiresAt:
+          typeof tokenJson.expires_in === 'number'
+            ? new Date(Date.now() + tokenJson.expires_in * 1000)
+            : undefined
+      }
+    };
+  }
+
+  private getClientId(): string {
+    const clientId = this.configService.get<string>('application.integrations.facebookClientId');
+    if (!clientId) {
+      throw new Error('Facebook OAuth client ID is not configured');
+    }
+
+    return clientId;
+  }
+
+  private getClientSecret(): string {
+    const clientSecret = this.configService.get<string>('application.integrations.facebookClientSecret');
+    if (!clientSecret) {
+      throw new Error('Facebook OAuth client secret is not configured');
+    }
+
+    return clientSecret;
+  }
+}

--- a/apps/backend/src/modules/auth/providers/google.provider.ts
+++ b/apps/backend/src/modules/auth/providers/google.provider.ts
@@ -1,0 +1,146 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import type {
+  AuthorizationUrlParams,
+  CodeExchangeParams,
+  OAuthExchangeResult,
+  OAuthProviderStrategy
+} from './oauth-provider.interface';
+
+@Injectable()
+export class GoogleOAuthProvider implements OAuthProviderStrategy {
+  readonly provider = 'google' as const;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  createAuthorizationUrl({ state, redirectUri }: AuthorizationUrlParams): string {
+    const clientId = this.getClientId();
+    const params = new URLSearchParams({
+      client_id: clientId,
+      response_type: 'code',
+      scope: 'openid email profile',
+      access_type: 'offline',
+      prompt: 'consent',
+      state
+    });
+
+    if (redirectUri) {
+      params.set('redirect_uri', redirectUri);
+    }
+
+    return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+  }
+
+  async exchangeCode({ code, redirectUri }: CodeExchangeParams): Promise<OAuthExchangeResult> {
+    const clientId = this.getClientId();
+    const clientSecret = this.getClientSecret();
+
+    const body = new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      grant_type: 'authorization_code'
+    });
+
+    if (redirectUri) {
+      body.set('redirect_uri', redirectUri);
+    }
+
+    const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString()
+    });
+
+    if (!tokenResponse.ok) {
+      throw new Error('Failed to exchange Google authorization code for tokens');
+    }
+
+    const tokenJson = (await tokenResponse.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+    };
+
+    const accessToken = tokenJson.access_token;
+    if (!accessToken) {
+      throw new Error('Google token response did not contain an access token');
+    }
+
+    const profileResponse = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+
+    if (!profileResponse.ok) {
+      throw new Error('Failed to load Google profile information');
+    }
+
+    const profileJson = (await profileResponse.json()) as {
+      id?: string;
+      email?: string;
+      given_name?: string;
+      family_name?: string;
+      name?: string;
+      picture?: string;
+    };
+
+    const providerId = profileJson.id;
+    const email = profileJson.email;
+
+    if (!providerId || !email) {
+      throw new Error('Google profile response did not contain the expected fields');
+    }
+
+    const [firstName, lastName] = this.extractNames(profileJson);
+
+    return {
+      provider: this.provider,
+      providerId,
+      email,
+      firstName,
+      lastName,
+      avatarUrl: profileJson.picture ?? undefined,
+      tokens: {
+        accessToken,
+        refreshToken: tokenJson.refresh_token ?? undefined,
+        expiresAt:
+          typeof tokenJson.expires_in === 'number'
+            ? new Date(Date.now() + tokenJson.expires_in * 1000)
+            : undefined
+      }
+    };
+  }
+
+  private getClientId(): string {
+    const clientId = this.configService.get<string>('application.integrations.googleClientId');
+    if (!clientId) {
+      throw new Error('Google OAuth client ID is not configured');
+    }
+
+    return clientId;
+  }
+
+  private getClientSecret(): string {
+    const clientSecret = this.configService.get<string>('application.integrations.googleClientSecret');
+    if (!clientSecret) {
+      throw new Error('Google OAuth client secret is not configured');
+    }
+
+    return clientSecret;
+  }
+
+  private extractNames(profile: { given_name?: string; family_name?: string; name?: string }): [string, string] {
+    if (profile.given_name || profile.family_name) {
+      return [profile.given_name ?? '', profile.family_name ?? ''];
+    }
+
+    if (profile.name) {
+      const parts = profile.name.split(' ');
+      const [first, ...rest] = parts;
+      return [first ?? '', rest.join(' ')];
+    }
+
+    return ['Google', 'User'];
+  }
+}

--- a/apps/backend/src/modules/auth/providers/index.ts
+++ b/apps/backend/src/modules/auth/providers/index.ts
@@ -1,0 +1,13 @@
+export { AppleOAuthProvider } from './apple.provider';
+export { FacebookOAuthProvider } from './facebook.provider';
+export { GoogleOAuthProvider } from './google.provider';
+export type {
+  AuthorizationUrlParams,
+  CodeExchangeParams,
+  OAuthExchangeResult,
+  OAuthProvider,
+  OAuthProviderStrategy,
+  OAuthTokens
+} from './oauth-provider.interface';
+
+export const AUTH_PROVIDER_STRATEGIES = Symbol('AUTH_PROVIDER_STRATEGIES');

--- a/apps/backend/src/modules/auth/providers/oauth-provider.interface.ts
+++ b/apps/backend/src/modules/auth/providers/oauth-provider.interface.ts
@@ -1,0 +1,38 @@
+import type { Provider } from '@covenant-connect/shared';
+
+export type OAuthProvider = Exclude<Provider, 'password'>;
+
+export type OAuthTokens = {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: Date;
+};
+
+export type OAuthProfile = {
+  provider: OAuthProvider;
+  providerId: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  avatarUrl?: string;
+};
+
+export type OAuthExchangeResult = OAuthProfile & {
+  tokens: OAuthTokens;
+};
+
+export type AuthorizationUrlParams = {
+  state: string;
+  redirectUri?: string;
+};
+
+export type CodeExchangeParams = {
+  code: string;
+  redirectUri?: string;
+};
+
+export interface OAuthProviderStrategy {
+  readonly provider: OAuthProvider;
+  createAuthorizationUrl(params: AuthorizationUrlParams): string;
+  exchangeCode(params: CodeExchangeParams): Promise<OAuthExchangeResult>;
+}

--- a/apps/backend/test/oauth.integration.test.js
+++ b/apps/backend/test/oauth.integration.test.js
@@ -1,0 +1,299 @@
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+require('reflect-metadata');
+
+const { ConfigService } = require('@nestjs/config');
+
+const { AccountsService } = require('../src/modules/accounts/accounts.service');
+const { AuthController } = require('../src/modules/auth/auth.controller');
+const { AuthService } = require('../src/modules/auth/auth.service');
+const { SessionStore } = require('../src/modules/auth/session.store');
+const { AppleOAuthProvider, FacebookOAuthProvider, GoogleOAuthProvider } = require('../src/modules/auth/providers');
+const { PrismaService } = require('../src/prisma/prisma.service');
+
+const backendRoot = path.resolve(__dirname, '..');
+const migrationsDir = path.join(backendRoot, 'prisma/migrations');
+
+const POSTGRES_HOST = process.env.PGHOST ?? 'localhost';
+const POSTGRES_PORT = process.env.PGPORT ?? '5432';
+const POSTGRES_USER = process.env.POSTGRES_USER ?? 'postgres';
+const POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD ?? 'postgres';
+
+const databaseName = `covenant_oauth_test_${Date.now()}`;
+const databaseUrl = `postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${databaseName}`;
+
+const psqlEnv = {
+  ...process.env,
+  PGPASSWORD: POSTGRES_PASSWORD
+};
+
+const APPLE_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgVeNDNxMtkr+Bc74T\nzMPCeDXmDtepU43qrAPy9nMBYX+hRANCAASkXWJMFa7XhffY/av0z07gG6ThuDky\nnxQ33IBcKeI/pwd8kNxXyuUN86hYKM3plAtlYWUO2Yw80gi8C8J2U0Yi\n-----END PRIVATE KEY-----`;
+
+function execPsql(args) {
+  execFileSync('psql', ['-q', ...args], { stdio: 'inherit', env: psqlEnv });
+}
+
+function applyMigrations() {
+  const migrations = fs
+    .readdirSync(migrationsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(migrationsDir, entry.name, 'migration.sql'))
+    .filter((migrationPath) => fs.existsSync(migrationPath))
+    .sort();
+
+  if (migrations.length === 0) {
+    throw new Error('No Prisma migration files found');
+  }
+
+  execPsql(['-h', POSTGRES_HOST, '-p', POSTGRES_PORT, '-U', POSTGRES_USER, '-c', `DROP DATABASE IF EXISTS "${databaseName}"`]);
+  execPsql(['-h', POSTGRES_HOST, '-p', POSTGRES_PORT, '-U', POSTGRES_USER, '-c', `CREATE DATABASE "${databaseName}"`]);
+
+  for (const migrationFile of migrations) {
+    execPsql([
+      '-v',
+      'ON_ERROR_STOP=1',
+      '-h',
+      POSTGRES_HOST,
+      '-p',
+      POSTGRES_PORT,
+      '-U',
+      POSTGRES_USER,
+      '-d',
+      databaseName,
+      '-f',
+      migrationFile
+    ]);
+  }
+}
+
+function makeIdToken(payload) {
+  const header = Buffer.from(JSON.stringify({ alg: 'ES256', kid: 'APPLE_KEY' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
+}
+
+describe('OAuth provider flows', () => {
+  let configService;
+  let prisma;
+  let accounts;
+  let sessions;
+  let authService;
+  let controller;
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = databaseUrl;
+
+    applyMigrations();
+
+    configService = new ConfigService({
+      database: { url: databaseUrl },
+      application: {
+        databaseUrl,
+        http: { cors: ['https://app.local'] },
+        integrations: {
+          googleClientId: 'google-client-id',
+          googleClientSecret: 'google-client-secret',
+          facebookClientId: 'facebook-client-id',
+          facebookClientSecret: 'facebook-client-secret',
+          appleClientId: 'apple.service.id',
+          appleTeamId: 'APPLE_TEAM',
+          appleKeyId: 'APPLE_KEY',
+          applePrivateKey: APPLE_PRIVATE_KEY
+        }
+      }
+    });
+
+    prisma = new PrismaService(configService);
+    await prisma.onModuleInit();
+
+    accounts = new AccountsService(prisma);
+    sessions = new SessionStore(prisma);
+
+    const google = new GoogleOAuthProvider(configService);
+    const facebook = new FacebookOAuthProvider(configService);
+    const apple = new AppleOAuthProvider(configService);
+
+    authService = new AuthService(accounts, sessions, configService, [google, facebook, apple]);
+    controller = new AuthController(authService);
+  }, 120000);
+
+  beforeEach(async () => {
+    await prisma.session.deleteMany();
+    await prisma.accountProvider.deleteMany();
+    await prisma.user.deleteMany();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  afterAll(async () => {
+    if (prisma?.onModuleDestroy) {
+      await prisma.onModuleDestroy();
+    }
+    execPsql(['-h', POSTGRES_HOST, '-p', POSTGRES_PORT, '-U', POSTGRES_USER, '-c', `DROP DATABASE IF EXISTS "${databaseName}"`]);
+  });
+
+  it('signs in new accounts with Google and stores tokens', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const start = await controller.startProviderLogin('google', {
+      redirectUri: 'https://app.local/oauth/callback',
+      state: 'client-state'
+    });
+
+    expect(start.authorizationUrl).toContain('google-client-id');
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'google-access-token',
+        refresh_token: 'google-refresh-token',
+        expires_in: 3600
+      })
+    });
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 'google-user-123',
+        email: 'google.user@example.com',
+        given_name: 'Google',
+        family_name: 'Tester',
+        picture: 'https://images.example.com/google-user.png'
+      })
+    });
+
+    const result = await controller.providerCallback('google', {
+      code: 'google-auth-code',
+      state: start.state
+    });
+
+    expect(result.account.email).toBe('google.user@example.com');
+    const googleIdentity = result.account.providers.find((provider) => provider.provider === 'google');
+    expect(googleIdentity?.accessToken).toBe('google-access-token');
+    expect(googleIdentity?.refreshToken).toBe('google-refresh-token');
+    expect(googleIdentity?.expiresAt).toBeInstanceOf(Date);
+    expect(result.redirectUri).toBe('https://app.local/oauth/callback');
+
+    const stored = await accounts.getAccountById(result.account.id);
+    expect(stored?.providers[0]?.accessToken).toBe('google-access-token');
+  });
+
+  it('refreshes Facebook tokens on repeated logins', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const start = await controller.startProviderLogin('facebook', {
+      redirectUri: 'https://app.local/oauth/callback'
+    });
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'facebook-access-token-1',
+        token_type: 'bearer',
+        expires_in: 3600
+      })
+    });
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 'facebook-user-1',
+        email: 'facebook.user@example.com',
+        first_name: 'Face',
+        last_name: 'Book'
+      })
+    });
+
+    const firstLogin = await controller.providerCallback('facebook', {
+      code: 'facebook-auth-code',
+      state: start.state
+    });
+
+    const firstIdentity = firstLogin.account.providers.find((provider) => provider.provider === 'facebook');
+    expect(firstIdentity?.accessToken).toBe('facebook-access-token-1');
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'facebook-access-token-2',
+        token_type: 'bearer',
+        expires_in: 7200
+      })
+    });
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 'facebook-user-1',
+        email: 'facebook.user@example.com',
+        first_name: 'Face',
+        last_name: 'Book'
+      })
+    });
+
+    const nextStart = await controller.startProviderLogin('facebook', {
+      redirectUri: 'https://app.local/oauth/callback'
+    });
+
+    const secondLogin = await controller.providerCallback('facebook', {
+      code: 'facebook-auth-code-2',
+      state: nextStart.state
+    });
+
+    const secondIdentity = secondLogin.account.providers.find((provider) => provider.provider === 'facebook');
+    expect(secondIdentity?.accessToken).toBe('facebook-access-token-2');
+    expect(secondIdentity?.expiresAt).toBeInstanceOf(Date);
+
+    const stored = await accounts.getAccountById(secondLogin.account.id);
+    const storedFacebook = stored?.providers.find((provider) => provider.provider === 'facebook');
+    expect(storedFacebook?.accessToken).toBe('facebook-access-token-2');
+  });
+
+  it('authenticates with Apple and persists refresh tokens', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const start = await controller.startProviderLogin('apple', {
+      redirectUri: 'https://app.local/oauth/callback'
+    });
+
+    const idToken = makeIdToken({
+      sub: 'apple-user-1',
+      email: 'apple.user@example.com',
+      given_name: 'Apple',
+      family_name: 'Tester'
+    });
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'apple-access-token',
+        refresh_token: 'apple-refresh-token',
+        expires_in: 600,
+        id_token: idToken
+      })
+    });
+
+    const result = await controller.providerCallback('apple', {
+      code: 'apple-auth-code',
+      state: start.state
+    });
+
+    const appleIdentity = result.account.providers.find((provider) => provider.provider === 'apple');
+    expect(appleIdentity?.accessToken).toBe('apple-access-token');
+    expect(appleIdentity?.refreshToken).toBe('apple-refresh-token');
+    expect(appleIdentity?.expiresAt).toBeInstanceOf(Date);
+    expect(result.redirectUri).toBe('https://app.local/oauth/callback');
+
+    const stored = await accounts.getAccountById(result.account.id);
+    const storedApple = stored?.providers.find((provider) => provider.provider === 'apple');
+    expect(storedApple?.refreshToken).toBe('apple-refresh-token');
+  });
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,9 @@
     "rootDir": "./",
     "baseUrl": "./",
     "resolveJsonModule": true,
-    "types": ["node"]
+    "types": ["node"],
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "useDefineForClassFields": false
   }
 }


### PR DESCRIPTION
## Summary
- add OAuth provider strategy infrastructure and Google, Facebook, Apple implementations backed by ConfigService credentials
- wire AuthService, AuthModule, and AuthController to execute real provider exchanges and persist access/refresh tokens
- expand configuration/decorator support and add integration tests that mock provider token/profile exchanges

## Testing
- npm test -w apps/backend -- --run *(fails: requires `psql` binary in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d123a53ae08333b1333eeba02917ca