### PR TITLE
feat: add donation payment providers

### DIFF
--- a/apps/backend/src/modules/donations/donations.module.ts
+++ b/apps/backend/src/modules/donations/donations.module.ts
@@ -2,10 +2,20 @@ import { Module } from '@nestjs/common';
 
 import { DonationsController } from './donations.controller';
 import { DonationsService } from './donations.service';
+import { PaystackPaymentProvider } from './providers/paystack.provider';
+import { FincraPaymentProvider } from './providers/fincra.provider';
+import { StripePaymentProvider } from './providers/stripe.provider';
+import { FlutterwavePaymentProvider } from './providers/flutterwave.provider';
 
 @Module({
   controllers: [DonationsController],
-  providers: [DonationsService],
+  providers: [
+    DonationsService,
+    PaystackPaymentProvider,
+    FincraPaymentProvider,
+    StripePaymentProvider,
+    FlutterwavePaymentProvider
+  ],
   exports: [DonationsService]
 })
 export class DonationsModule {}

--- a/apps/backend/src/modules/donations/donations.service.ts
+++ b/apps/backend/src/modules/donations/donations.service.ts
@@ -1,9 +1,14 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import type { Donation as DonationModel } from '@prisma/client';
 import type { Donation, PaginatedResult, Pagination } from '@covenant-connect/shared';
 
 import { PrismaService } from '../../prisma/prisma.service';
+import type { DonationPaymentProvider } from './providers/payment-provider.interface';
+import { PaystackPaymentProvider } from './providers/paystack.provider';
+import { FincraPaymentProvider } from './providers/fincra.provider';
+import { StripePaymentProvider } from './providers/stripe.provider';
+import { FlutterwavePaymentProvider } from './providers/flutterwave.provider';
 
 type CreateDonationInput = {
   memberId?: string | null;
@@ -20,7 +25,22 @@ type UpdateDonationStatusInput = {
 
 @Injectable()
 export class DonationsService {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly providers: Record<Donation['provider'], DonationPaymentProvider>;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    paystackProvider: PaystackPaymentProvider,
+    fincraProvider: FincraPaymentProvider,
+    stripeProvider: StripePaymentProvider,
+    flutterwaveProvider: FlutterwavePaymentProvider
+  ) {
+    this.providers = {
+      paystack: paystackProvider,
+      fincra: fincraProvider,
+      stripe: stripeProvider,
+      flutterwave: flutterwaveProvider
+    };
+  }
 
   async list(pagination: Pagination): Promise<PaginatedResult<Donation>> {
     const skip = (pagination.page - 1) * pagination.pageSize;
@@ -45,14 +65,34 @@ export class DonationsService {
 
   async create(input: CreateDonationInput): Promise<Donation> {
     const memberId = this.parseMemberId(input.memberId);
+    const provider = this.getProvider(input.provider);
+    const baseMetadata = this.cloneMetadata(input.metadata);
+
+    const initialization = await provider.initializePayment({
+      amount: input.amount,
+      currency: input.currency,
+      metadata: baseMetadata
+    });
+
+    const combinedMetadata = {
+      ...baseMetadata,
+      ...initialization.metadata
+    };
+
+    if (!combinedMetadata.reference) {
+      combinedMetadata.reference = initialization.reference;
+    }
+
     const created = await this.prisma.donation.create({
       data: {
         memberId,
         amount: new Prisma.Decimal(input.amount),
         currency: input.currency,
         paymentMethod: input.provider,
-        metadata: input.metadata ?? {},
-        status: 'pending'
+        metadata: combinedMetadata,
+        status: initialization.status ?? 'pending',
+        reference: initialization.reference,
+        transactionId: initialization.transactionId ?? null
       }
     });
 
@@ -68,14 +108,48 @@ export class DonationsService {
       throw new NotFoundException('Donation not found');
     }
 
+    const provider = this.getProvider(existing.paymentMethod as Donation['provider']);
+    const existingMetadata = this.parseMetadata(existing.metadata);
+    let status = input.status;
+    let transactionId = existing.transactionId;
+    let providerMetadata: Record<string, unknown> = {};
+
+    if (input.status === 'completed') {
+      const reference = this.ensureReference(existing);
+      const verification = await provider.verifyPayment({
+        reference,
+        metadata: existingMetadata
+      });
+      status = verification.status ?? input.status;
+      transactionId = verification.transactionId ?? transactionId;
+      providerMetadata = verification.metadata;
+    } else if (input.status === 'refunded') {
+      const reference = this.getRefundReference(existing);
+      const amount = this.getAmountValue(existing.amount);
+      const refund = await provider.refund({
+        reference,
+        amount,
+        metadata: existingMetadata
+      });
+      providerMetadata = refund.metadata;
+    }
+
+    const combinedMetadata = {
+      ...existingMetadata,
+      ...providerMetadata,
+      ...(input.metadata ?? {})
+    };
+
+    if (existing.reference && !combinedMetadata.reference) {
+      combinedMetadata.reference = existing.reference;
+    }
+
     const updated = await this.prisma.donation.update({
       where: { id: existing.id },
       data: {
-        status: input.status,
-        metadata: {
-          ...((existing.metadata as Record<string, unknown>) ?? {}),
-          ...(input.metadata ?? {})
-        }
+        status,
+        metadata: combinedMetadata,
+        transactionId: transactionId ?? existing.transactionId ?? null
       }
     });
 
@@ -113,5 +187,50 @@ export class DonationsService {
     }
 
     return parsed;
+  }
+
+  private getProvider(provider: Donation['provider']): DonationPaymentProvider {
+    const resolved = this.providers[provider];
+    if (!resolved) {
+      throw new BadRequestException(`Unsupported donation provider: ${provider}`);
+    }
+
+    return resolved;
+  }
+
+  private cloneMetadata(metadata?: Record<string, unknown>): Record<string, unknown> {
+    if (!metadata) {
+      return {};
+    }
+
+    return { ...metadata };
+  }
+
+  private parseMetadata(metadata: Prisma.JsonValue | null | undefined): Record<string, unknown> {
+    if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
+      return { ...(metadata as Record<string, unknown>) };
+    }
+
+    return {};
+  }
+
+  private ensureReference(record: DonationModel): string {
+    if (record.reference) {
+      return record.reference;
+    }
+
+    throw new BadRequestException('Donation does not have a provider reference');
+  }
+
+  private getRefundReference(record: DonationModel): string {
+    if (record.transactionId) {
+      return record.transactionId;
+    }
+
+    return this.ensureReference(record);
+  }
+
+  private getAmountValue(amount: Prisma.Decimal | number): number {
+    return amount instanceof Prisma.Decimal ? amount.toNumber() : Number(amount);
   }
 }

--- a/apps/backend/src/modules/donations/providers/fincra.provider.ts
+++ b/apps/backend/src/modules/donations/providers/fincra.provider.ts
@@ -1,0 +1,240 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'node:crypto';
+import type { Donation } from '@covenant-connect/shared';
+
+import type {
+  DonationPaymentProvider,
+  InitializePaymentInput,
+  InitializePaymentResult,
+  RefundPaymentInput,
+  RefundPaymentResult,
+  VerifyPaymentInput,
+  VerifyPaymentResult
+} from './payment-provider.interface';
+
+@Injectable()
+export class FincraPaymentProvider implements DonationPaymentProvider {
+  constructor(private readonly configService: ConfigService) {}
+
+  async initializePayment(input: InitializePaymentInput): Promise<InitializePaymentResult> {
+    const secretKey = this.getSecretKey();
+    const metadata = this.cloneMetadata(input.metadata);
+
+    const email = this.requireString(metadata, 'email', 'Fincra initialization requires an email');
+    const firstName = this.requireString(metadata, 'firstName', 'Fincra initialization requires a first name');
+    const lastName = this.requireString(metadata, 'lastName', 'Fincra initialization requires a last name');
+    const callbackUrl = this.requireString(metadata, 'callbackUrl', 'Fincra initialization requires a callbackUrl');
+    const country = this.tryString(metadata, 'country');
+    const reference = this.extractReference(metadata);
+
+    const payload: Record<string, unknown> = {
+      amount: input.amount.toFixed(2),
+      currency: input.currency,
+      reference,
+      customer: {
+        firstName,
+        lastName,
+        email
+      },
+      redirectUrl: callbackUrl,
+      paymentType: 'card'
+    };
+
+    if (country) {
+      payload.country = country;
+    }
+
+    const response = await this.request('initialize', 'https://api.fincra.com/checkout/payments', {
+      method: 'POST',
+      headers: {
+        'api-key': secretKey,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const json = await this.parseJson<{ data?: Record<string, unknown> }>(response, 'initialize');
+    const data = this.ensureRecord(json.data);
+    const authorizationUrl =
+      this.tryString(data, 'checkoutUrl') ??
+      this.tryString(data, 'checkout_url') ??
+      this.tryString(data, 'paymentLink') ??
+      this.tryString(data, 'link');
+
+    if (!authorizationUrl) {
+      throw new Error('Fincra initialize response did not include a checkout URL');
+    }
+
+    const resolvedReference =
+      this.tryString(data, 'transactionReference') ?? this.tryString(data, 'reference') ?? reference;
+    const transactionId = this.tryString(data, 'id') ?? this.tryString(data, 'transactionId');
+
+    return {
+      reference: resolvedReference,
+      transactionId: transactionId ?? null,
+      metadata: {
+        authorizationUrl,
+        providerReference: resolvedReference,
+        fincra: {
+          response: data
+        }
+      },
+      status: 'pending'
+    };
+  }
+
+  async verifyPayment(input: VerifyPaymentInput): Promise<VerifyPaymentResult> {
+    const secretKey = this.getSecretKey();
+    const url = `https://api.fincra.com/checkout/payments/${encodeURIComponent(input.reference)}`;
+
+    const response = await this.request('verify', url, {
+      method: 'GET',
+      headers: {
+        'api-key': secretKey
+      }
+    });
+
+    const json = await this.parseJson<{ data?: Record<string, unknown> }>(response, 'verify');
+    const data = this.ensureRecord(json.data);
+
+    return {
+      status: this.normaliseStatus(this.tryString(data, 'status')),
+      transactionId: this.tryString(data, 'id') ?? this.tryString(data, 'transactionId') ?? null,
+      metadata: {
+        verification: data,
+        fincra: {
+          verification: data
+        }
+      }
+    };
+  }
+
+  async refund(input: RefundPaymentInput): Promise<RefundPaymentResult> {
+    const secretKey = this.getSecretKey();
+    const url = `https://api.fincra.com/transactions/${encodeURIComponent(input.reference)}/refund`;
+
+    const payload = {
+      amount: input.amount.toFixed(2)
+    };
+
+    const response = await this.request('refund', url, {
+      method: 'POST',
+      headers: {
+        'api-key': secretKey,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const json = await this.parseJson<Record<string, unknown>>(response, 'refund');
+
+    return {
+      metadata: {
+        refund: json,
+        fincra: {
+          refund: json
+        }
+      }
+    };
+  }
+
+  private getSecretKey(): string {
+    const key = this.configService.get<string>('application.payments.fincraKey');
+    if (!key) {
+      throw new Error('Fincra secret key is not configured');
+    }
+
+    return key;
+  }
+
+  private extractReference(metadata: Record<string, unknown>): string {
+    const reference = metadata.reference;
+    if (typeof reference === 'string' && reference.trim().length > 0) {
+      return reference;
+    }
+
+    return randomUUID();
+  }
+
+  private requireString(metadata: Record<string, unknown>, key: string, message: string): string {
+    const value = metadata[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+
+    throw new Error(message);
+  }
+
+  private tryString(metadata: Record<string, unknown>, key: string): string | null {
+    const value = metadata[key];
+    return typeof value === 'string' ? value : null;
+  }
+
+  private cloneMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+    return { ...metadata };
+  }
+
+  private ensureRecord(value: unknown): Record<string, unknown> {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+
+    return {};
+  }
+
+  private normaliseStatus(status: string | null | undefined): Donation['status'] {
+    if (!status) {
+      return 'pending';
+    }
+
+    const normalised = status.toLowerCase();
+    if (normalised.includes('success')) {
+      return 'completed';
+    }
+    if (normalised.includes('fail')) {
+      return 'failed';
+    }
+    if (normalised.includes('refund')) {
+      return 'refunded';
+    }
+
+    return 'pending';
+  }
+
+  private async request(action: string, url: string, init: RequestInit): Promise<Response> {
+    try {
+      const response = await fetch(url, init);
+      if (!response.ok) {
+        const body = await this.safeReadBody(response);
+        throw new Error(`Fincra ${action} request failed with status ${response.status}: ${body}`);
+      }
+
+      return response;
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Fincra')) {
+        throw error;
+      }
+
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Fincra ${action} request failed: ${message}`);
+    }
+  }
+
+  private async parseJson<T>(response: Response, action: string): Promise<T> {
+    try {
+      return (await response.json()) as T;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Fincra ${action} response was not valid JSON: ${message}`);
+    }
+  }
+
+  private async safeReadBody(response: Response): Promise<string> {
+    try {
+      return await response.text();
+    } catch {
+      return '';
+    }
+  }
+}

--- a/apps/backend/src/modules/donations/providers/flutterwave.provider.ts
+++ b/apps/backend/src/modules/donations/providers/flutterwave.provider.ts
@@ -1,0 +1,226 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'node:crypto';
+import type { Donation } from '@covenant-connect/shared';
+
+import type {
+  DonationPaymentProvider,
+  InitializePaymentInput,
+  InitializePaymentResult,
+  RefundPaymentInput,
+  RefundPaymentResult,
+  VerifyPaymentInput,
+  VerifyPaymentResult
+} from './payment-provider.interface';
+
+@Injectable()
+export class FlutterwavePaymentProvider implements DonationPaymentProvider {
+  constructor(private readonly configService: ConfigService) {}
+
+  async initializePayment(input: InitializePaymentInput): Promise<InitializePaymentResult> {
+    const secretKey = this.getSecretKey();
+    const metadata = this.cloneMetadata(input.metadata);
+
+    const email = this.requireString(metadata, 'email', 'Flutterwave initialization requires an email');
+    const callbackUrl = this.requireString(metadata, 'callbackUrl', 'Flutterwave initialization requires a callbackUrl');
+    const reference = this.extractReference(metadata);
+
+    const payload = {
+      tx_ref: reference,
+      amount: input.amount.toFixed(2),
+      currency: input.currency,
+      redirect_url: callbackUrl,
+      customer: {
+        email
+      },
+      payment_options: 'card'
+    };
+
+    const response = await this.request('initialize', 'https://api.flutterwave.com/v3/payments', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${secretKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const json = await this.parseJson<{ data?: Record<string, unknown> }>(response, 'initialize');
+    const data = this.ensureRecord(json.data);
+    const authorizationUrl = this.tryString(data, 'link') ?? this.tryString(data, 'url');
+
+    if (!authorizationUrl) {
+      throw new Error('Flutterwave initialize response did not include a checkout URL');
+    }
+
+    const resolvedReference = this.tryString(data, 'tx_ref') ?? this.tryString(data, 'flw_ref') ?? this.tryString(data, 'id') ?? reference;
+    const transactionId = this.tryString(data, 'id') ?? this.tryString(data, 'flw_ref');
+
+    return {
+      reference: resolvedReference,
+      transactionId: transactionId ?? null,
+      metadata: {
+        authorizationUrl,
+        providerReference: resolvedReference,
+        flutterwave: {
+          response: data
+        }
+      },
+      status: 'pending'
+    };
+  }
+
+  async verifyPayment(input: VerifyPaymentInput): Promise<VerifyPaymentResult> {
+    const secretKey = this.getSecretKey();
+    const url = `https://api.flutterwave.com/v3/transactions/${encodeURIComponent(input.reference)}/verify`;
+
+    const response = await this.request('verify', url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${secretKey}`
+      }
+    });
+
+    const json = await this.parseJson<{ data?: Record<string, unknown> }>(response, 'verify');
+    const data = this.ensureRecord(json.data);
+
+    return {
+      status: this.normaliseStatus(this.tryString(data, 'status')),
+      transactionId: this.tryString(data, 'id') ?? this.tryString(data, 'flw_ref') ?? null,
+      metadata: {
+        verification: data,
+        flutterwave: {
+          verification: data
+        }
+      }
+    };
+  }
+
+  async refund(input: RefundPaymentInput): Promise<RefundPaymentResult> {
+    const secretKey = this.getSecretKey();
+    const url = `https://api.flutterwave.com/v3/transactions/${encodeURIComponent(input.reference)}/refund`;
+
+    const payload = {
+      amount: input.amount.toFixed(2)
+    };
+
+    const response = await this.request('refund', url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${secretKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const json = await this.parseJson<Record<string, unknown>>(response, 'refund');
+
+    return {
+      metadata: {
+        refund: json,
+        flutterwave: {
+          refund: json
+        }
+      }
+    };
+  }
+
+  private getSecretKey(): string {
+    const key = this.configService.get<string>('application.payments.flutterwaveKey');
+    if (!key) {
+      throw new Error('Flutterwave secret key is not configured');
+    }
+
+    return key;
+  }
+
+  private extractReference(metadata: Record<string, unknown>): string {
+    const reference = metadata.reference;
+    if (typeof reference === 'string' && reference.trim().length > 0) {
+      return reference;
+    }
+
+    return randomUUID();
+  }
+
+  private requireString(metadata: Record<string, unknown>, key: string, message: string): string {
+    const value = metadata[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+
+    throw new Error(message);
+  }
+
+  private tryString(record: Record<string, unknown>, key: string): string | null {
+    const value = record[key];
+    return typeof value === 'string' ? value : null;
+  }
+
+  private cloneMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+    return { ...metadata };
+  }
+
+  private ensureRecord(value: unknown): Record<string, unknown> {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+
+    return {};
+  }
+
+  private normaliseStatus(status: string | null | undefined): Donation['status'] {
+    if (!status) {
+      return 'pending';
+    }
+
+    const normalised = status.toLowerCase();
+    if (normalised.includes('success')) {
+      return 'completed';
+    }
+    if (normalised.includes('fail')) {
+      return 'failed';
+    }
+    if (normalised.includes('refund')) {
+      return 'refunded';
+    }
+
+    return 'pending';
+  }
+
+  private async request(action: string, url: string, init: RequestInit): Promise<Response> {
+    try {
+      const response = await fetch(url, init);
+      if (!response.ok) {
+        const body = await this.safeReadBody(response);
+        throw new Error(`Flutterwave ${action} request failed with status ${response.status}: ${body}`);
+      }
+
+      return response;
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Flutterwave')) {
+        throw error;
+      }
+
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Flutterwave ${action} request failed: ${message}`);
+    }
+  }
+
+  private async parseJson<T>(response: Response, action: string): Promise<T> {
+    try {
+      return (await response.json()) as T;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Flutterwave ${action} response was not valid JSON: ${message}`);
+    }
+  }
+
+  private async safeReadBody(response: Response): Promise<string> {
+    try {
+      return await response.text();
+    } catch {
+      return '';
+    }
+  }
+}

--- a/apps/backend/src/modules/donations/providers/payment-provider.interface.ts
+++ b/apps/backend/src/modules/donations/providers/payment-provider.interface.ts
@@ -1,0 +1,41 @@
+import type { Donation } from '@covenant-connect/shared';
+
+export type InitializePaymentInput = {
+  amount: number;
+  currency: string;
+  metadata: Record<string, unknown>;
+};
+
+export type InitializePaymentResult = {
+  reference: string;
+  transactionId?: string | null;
+  metadata: Record<string, unknown>;
+  status?: Donation['status'];
+};
+
+export type VerifyPaymentInput = {
+  reference: string;
+  metadata: Record<string, unknown>;
+};
+
+export type VerifyPaymentResult = {
+  status: Donation['status'];
+  transactionId?: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export type RefundPaymentInput = {
+  reference: string;
+  amount: number;
+  metadata: Record<string, unknown>;
+};
+
+export type RefundPaymentResult = {
+  metadata: Record<string, unknown>;
+};
+
+export interface DonationPaymentProvider {
+  initializePayment(input: InitializePaymentInput): Promise<InitializePaymentResult>;
+  verifyPayment(input: VerifyPaymentInput): Promise<VerifyPaymentResult>;
+  refund(input: RefundPaymentInput): Promise<RefundPaymentResult>;
+}

--- a/apps/backend/src/modules/donations/providers/paystack.provider.ts
+++ b/apps/backend/src/modules/donations/providers/paystack.provider.ts
@@ -1,0 +1,224 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'node:crypto';
+import type { Donation } from '@covenant-connect/shared';
+
+import type {
+  DonationPaymentProvider,
+  InitializePaymentInput,
+  InitializePaymentResult,
+  RefundPaymentInput,
+  RefundPaymentResult,
+  VerifyPaymentInput,
+  VerifyPaymentResult
+} from './payment-provider.interface';
+
+@Injectable()
+export class PaystackPaymentProvider implements DonationPaymentProvider {
+  constructor(private readonly configService: ConfigService) {}
+
+  async initializePayment(input: InitializePaymentInput): Promise<InitializePaymentResult> {
+    const secretKey = this.getSecretKey();
+    const metadata = this.cloneMetadata(input.metadata);
+    const email = this.requireString(metadata, 'email', 'Paystack initialization requires an email');
+    const callbackUrl = this.requireString(metadata, 'callbackUrl', 'Paystack initialization requires a callbackUrl');
+    const reference = this.extractReference(metadata);
+
+    const payload = {
+      amount: Math.round(input.amount * 100),
+      currency: input.currency,
+      email,
+      reference,
+      callback_url: callbackUrl
+    };
+
+    const response = await this.request('initialize', 'https://api.paystack.co/transaction/initialize', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${secretKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const json = await this.parseJson<{ data?: Record<string, unknown>; authorization_url?: string }>(response, 'initialize');
+    const data = this.ensureRecord(json.data);
+    const authorizationUrl = this.tryString(data, 'authorization_url') ?? this.tryString(json, 'authorization_url');
+
+    if (!authorizationUrl) {
+      throw new Error('Paystack initialize response did not include an authorization URL');
+    }
+
+    const resolvedReference = this.tryString(data, 'reference') ?? reference;
+    const transactionId = this.tryString(data, 'id');
+
+    return {
+      reference: resolvedReference,
+      transactionId: transactionId ?? null,
+      metadata: {
+        authorizationUrl,
+        providerReference: resolvedReference,
+        paystack: {
+          response: data
+        }
+      },
+      status: 'pending'
+    };
+  }
+
+  async verifyPayment(input: VerifyPaymentInput): Promise<VerifyPaymentResult> {
+    const secretKey = this.getSecretKey();
+    const url = `https://api.paystack.co/transaction/verify/${encodeURIComponent(input.reference)}`;
+
+    const response = await this.request('verify', url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${secretKey}`
+      }
+    });
+
+    const json = await this.parseJson<{ data?: Record<string, unknown> }>(response, 'verify');
+    const data = this.ensureRecord(json.data);
+    const status = this.normaliseStatus(this.tryString(data, 'status'));
+    const transactionId = this.tryString(data, 'id');
+
+    return {
+      status,
+      transactionId: transactionId ?? null,
+      metadata: {
+        verification: data,
+        paystack: {
+          verification: data
+        }
+      }
+    };
+  }
+
+  async refund(input: RefundPaymentInput): Promise<RefundPaymentResult> {
+    const secretKey = this.getSecretKey();
+
+    const payload = {
+      transaction: input.reference,
+      amount: Math.round(input.amount * 100)
+    };
+
+    const response = await this.request('refund', 'https://api.paystack.co/refund', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${secretKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const json = await this.parseJson<Record<string, unknown>>(response, 'refund');
+
+    return {
+      metadata: {
+        refund: json,
+        paystack: {
+          refund: json
+        }
+      }
+    };
+  }
+
+  private getSecretKey(): string {
+    const key = this.configService.get<string>('application.payments.paystackKey');
+    if (!key) {
+      throw new Error('Paystack secret key is not configured');
+    }
+
+    return key;
+  }
+
+  private extractReference(metadata: Record<string, unknown>): string {
+    const reference = metadata.reference;
+    if (typeof reference === 'string' && reference.trim().length > 0) {
+      return reference;
+    }
+
+    return randomUUID();
+  }
+
+  private requireString(metadata: Record<string, unknown>, key: string, message: string): string {
+    const value = metadata[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+
+    throw new Error(message);
+  }
+
+  private cloneMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+    return { ...metadata };
+  }
+
+  private ensureRecord(value: unknown): Record<string, unknown> {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+
+    return {};
+  }
+
+  private tryString(record: Record<string, unknown>, key: string): string | null {
+    const value = record[key];
+    return typeof value === 'string' ? value : null;
+  }
+
+  private normaliseStatus(status: string | null | undefined): Donation['status'] {
+    if (!status) {
+      return 'pending';
+    }
+
+    const normalised = status.toLowerCase();
+    if (normalised.includes('success')) {
+      return 'completed';
+    }
+    if (normalised.includes('fail')) {
+      return 'failed';
+    }
+    if (normalised.includes('refund')) {
+      return 'refunded';
+    }
+
+    return 'pending';
+  }
+
+  private async request(action: string, url: string, init: RequestInit): Promise<Response> {
+    try {
+      const response = await fetch(url, init);
+      if (!response.ok) {
+        const body = await this.safeReadBody(response);
+        throw new Error(`Paystack ${action} request failed with status ${response.status}: ${body}`);
+      }
+
+      return response;
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Paystack')) {
+        throw error;
+      }
+
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Paystack ${action} request failed: ${message}`);
+    }
+  }
+
+  private async parseJson<T>(response: Response, action: string): Promise<T> {
+    try {
+      return (await response.json()) as T;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Paystack ${action} response was not valid JSON: ${message}`);
+    }
+  }
+
+  private async safeReadBody(response: Response): Promise<string> {
+    try {
+      return await response.text();
+    } catch {
+      return '';
+    }
+  }
+}

--- a/apps/backend/src/modules/donations/providers/stripe.provider.ts
+++ b/apps/backend/src/modules/donations/providers/stripe.provider.ts
@@ -1,0 +1,226 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'node:crypto';
+import type { Donation } from '@covenant-connect/shared';
+
+import type {
+  DonationPaymentProvider,
+  InitializePaymentInput,
+  InitializePaymentResult,
+  RefundPaymentInput,
+  RefundPaymentResult,
+  VerifyPaymentInput,
+  VerifyPaymentResult
+} from './payment-provider.interface';
+
+@Injectable()
+export class StripePaymentProvider implements DonationPaymentProvider {
+  constructor(private readonly configService: ConfigService) {}
+
+  async initializePayment(input: InitializePaymentInput): Promise<InitializePaymentResult> {
+    const secretKey = this.getSecretKey();
+    const metadata = this.cloneMetadata(input.metadata);
+
+    const email = this.requireString(metadata, 'email', 'Stripe initialization requires an email');
+    const successUrl = this.requireString(metadata, 'successUrl', 'Stripe initialization requires a successUrl');
+    const cancelUrl = this.requireString(metadata, 'cancelUrl', 'Stripe initialization requires a cancelUrl');
+    const reference = this.extractReference(metadata);
+
+    const amountInMinorUnits = Math.round(input.amount * 100);
+    const params = new URLSearchParams({
+      mode: 'payment',
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      'line_items[0][price_data][currency]': input.currency.toLowerCase(),
+      'line_items[0][price_data][product_data][name]': 'Donation',
+      'line_items[0][price_data][unit_amount]': amountInMinorUnits.toString(),
+      'line_items[0][quantity]': '1',
+      customer_email: email,
+      client_reference_id: reference
+    });
+
+    const response = await this.request('initialize', 'https://api.stripe.com/v1/checkout/sessions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${secretKey}`,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: params
+    });
+
+    const session = await this.parseJson<Record<string, unknown>>(response, 'initialize');
+    const url = this.requireRecordString(session, 'url', 'Stripe initialize response did not include a checkout URL');
+    const sessionId = this.requireRecordString(session, 'id', 'Stripe initialize response did not include a session id');
+    const paymentIntent = this.tryString(session, 'payment_intent');
+
+    return {
+      reference: sessionId,
+      transactionId: paymentIntent ?? null,
+      metadata: {
+        authorizationUrl: url,
+        providerReference: sessionId,
+        stripe: {
+          session
+        }
+      },
+      status: 'pending'
+    };
+  }
+
+  async verifyPayment(input: VerifyPaymentInput): Promise<VerifyPaymentResult> {
+    const secretKey = this.getSecretKey();
+    const url = `https://api.stripe.com/v1/checkout/sessions/${encodeURIComponent(input.reference)}`;
+
+    const response = await this.request('verify', url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${secretKey}`
+      }
+    });
+
+    const session = await this.parseJson<Record<string, unknown>>(response, 'verify');
+    const paymentStatus = this.tryString(session, 'payment_status') ?? this.tryString(session, 'status');
+    const transactionId = this.tryString(session, 'payment_intent') ?? this.tryString(session, 'id');
+
+    return {
+      status: this.normaliseStatus(paymentStatus),
+      transactionId: transactionId ?? null,
+      metadata: {
+        verification: session,
+        stripe: {
+          verification: session
+        }
+      }
+    };
+  }
+
+  async refund(input: RefundPaymentInput): Promise<RefundPaymentResult> {
+    const secretKey = this.getSecretKey();
+    const amountInMinorUnits = Math.round(input.amount * 100);
+
+    const params = new URLSearchParams({
+      payment_intent: input.reference,
+      amount: amountInMinorUnits.toString()
+    });
+
+    const response = await this.request('refund', 'https://api.stripe.com/v1/refunds', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${secretKey}`,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: params
+    });
+
+    const refund = await this.parseJson<Record<string, unknown>>(response, 'refund');
+
+    return {
+      metadata: {
+        refund,
+        stripe: {
+          refund
+        }
+      }
+    };
+  }
+
+  private getSecretKey(): string {
+    const key = this.configService.get<string>('application.payments.stripeKey');
+    if (!key) {
+      throw new Error('Stripe secret key is not configured');
+    }
+
+    return key;
+  }
+
+  private extractReference(metadata: Record<string, unknown>): string {
+    const reference = metadata.reference;
+    if (typeof reference === 'string' && reference.trim().length > 0) {
+      return reference;
+    }
+
+    return randomUUID();
+  }
+
+  private requireString(metadata: Record<string, unknown>, key: string, message: string): string {
+    const value = metadata[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+
+    throw new Error(message);
+  }
+
+  private requireRecordString(record: Record<string, unknown>, key: string, message: string): string {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+
+    throw new Error(message);
+  }
+
+  private tryString(record: Record<string, unknown>, key: string): string | null {
+    const value = record[key];
+    return typeof value === 'string' ? value : null;
+  }
+
+  private cloneMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+    return { ...metadata };
+  }
+
+  private normaliseStatus(status: string | null | undefined): Donation['status'] {
+    if (!status) {
+      return 'pending';
+    }
+
+    const normalised = status.toLowerCase();
+    if (normalised.includes('paid') || normalised.includes('success')) {
+      return 'completed';
+    }
+    if (normalised.includes('fail')) {
+      return 'failed';
+    }
+    if (normalised.includes('refund')) {
+      return 'refunded';
+    }
+
+    return 'pending';
+  }
+
+  private async request(action: string, url: string, init: RequestInit): Promise<Response> {
+    try {
+      const response = await fetch(url, init);
+      if (!response.ok) {
+        const body = await this.safeReadBody(response);
+        throw new Error(`Stripe ${action} request failed with status ${response.status}: ${body}`);
+      }
+
+      return response;
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Stripe')) {
+        throw error;
+      }
+
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Stripe ${action} request failed: ${message}`);
+    }
+  }
+
+  private async parseJson<T>(response: Response, action: string): Promise<T> {
+    try {
+      return (await response.json()) as T;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Stripe ${action} response was not valid JSON: ${message}`);
+    }
+  }
+
+  private async safeReadBody(response: Response): Promise<string> {
+    try {
+      return await response.text();
+    } catch {
+      return '';
+    }
+  }
+}

--- a/apps/backend/test/donation.providers.spec.ts
+++ b/apps/backend/test/donation.providers.spec.ts
@@ -1,0 +1,475 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import type { ConfigService } from '@nestjs/config';
+
+import { PaystackPaymentProvider } from '../src/modules/donations/providers/paystack.provider';
+import { FincraPaymentProvider } from '../src/modules/donations/providers/fincra.provider';
+import { StripePaymentProvider } from '../src/modules/donations/providers/stripe.provider';
+import { FlutterwavePaymentProvider } from '../src/modules/donations/providers/flutterwave.provider';
+
+const createConfig = (values: Record<string, string | null>): ConfigService => {
+  return {
+    get: (key: string) => (key in values ? values[key] ?? null : null)
+  } as unknown as ConfigService;
+};
+
+const createResponse = (
+  body: unknown,
+  init: { ok?: boolean; status?: number; text?: string } = {}
+): Response => {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => body,
+    text: async () => init.text ?? JSON.stringify(body)
+  } as Response;
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('PaystackPaymentProvider', () => {
+  const config = createConfig({ 'application.payments.paystackKey': 'paystack-secret' });
+  const provider = new PaystackPaymentProvider(config);
+
+  it('initializes payments with the expected payload', async () => {
+    fetchMock.mockResolvedValue(
+      createResponse({
+        data: {
+          authorization_url: 'https://paystack.test/redirect',
+          reference: 'paystack-ref',
+          id: 'paystack-transaction'
+        }
+      })
+    );
+
+    const result = await provider.initializePayment({
+      amount: 50,
+      currency: 'NGN',
+      metadata: {
+        email: 'donor@example.com',
+        callbackUrl: 'https://example.com/callback',
+        reference: 'paystack-ref'
+      }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.paystack.co/transaction/initialize',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer paystack-secret',
+          'Content-Type': 'application/json'
+        })
+      })
+    );
+
+    const body = fetchMock.mock.calls[0][1]?.body as string;
+    expect(JSON.parse(body)).toEqual({
+      amount: 5000,
+      currency: 'NGN',
+      email: 'donor@example.com',
+      reference: 'paystack-ref',
+      callback_url: 'https://example.com/callback'
+    });
+
+    expect(result).toMatchObject({
+      reference: 'paystack-ref',
+      transactionId: 'paystack-transaction',
+      status: 'pending',
+      metadata: expect.objectContaining({
+        authorizationUrl: 'https://paystack.test/redirect'
+      })
+    });
+  });
+
+  it('verifies payments and normalizes status', async () => {
+    fetchMock.mockResolvedValue(
+      createResponse({ data: { status: 'success', id: 'paystack-transaction', reference: 'paystack-ref' } })
+    );
+
+    const result = await provider.verifyPayment({ reference: 'paystack-ref', metadata: {} });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.paystack.co/transaction/verify/paystack-ref',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Authorization: 'Bearer paystack-secret' })
+      })
+    );
+
+    expect(result.status).toBe('completed');
+    expect(result.transactionId).toBe('paystack-transaction');
+    expect(result.metadata).toHaveProperty('verification');
+  });
+
+  it('creates refunds with the transaction reference', async () => {
+    fetchMock.mockResolvedValue(createResponse({ data: { status: 'success' } }));
+
+    const result = await provider.refund({ reference: 'paystack-ref', amount: 50, metadata: {} });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.paystack.co/refund',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer paystack-secret',
+          'Content-Type': 'application/json'
+        })
+      })
+    );
+
+    const body = fetchMock.mock.calls[0][1]?.body as string;
+    expect(JSON.parse(body)).toEqual({ transaction: 'paystack-ref', amount: 5000 });
+    expect(result.metadata).toHaveProperty('refund');
+  });
+
+  it('throws when the Paystack API responds with an error', async () => {
+    fetchMock.mockResolvedValue(createResponse({}, { ok: false, status: 400, text: 'bad request' }));
+
+    await expect(
+      provider.initializePayment({
+        amount: 50,
+        currency: 'NGN',
+        metadata: {
+          email: 'donor@example.com',
+          callbackUrl: 'https://example.com/callback',
+          reference: 'paystack-ref'
+        }
+      })
+    ).rejects.toThrow(/Paystack initialize request failed/);
+  });
+});
+
+describe('FincraPaymentProvider', () => {
+  const config = createConfig({ 'application.payments.fincraKey': 'fincra-secret' });
+  const provider = new FincraPaymentProvider(config);
+
+  it('initializes checkout sessions', async () => {
+    fetchMock.mockResolvedValue(
+      createResponse({
+        data: {
+          checkoutUrl: 'https://fincra.test/checkout',
+          transactionReference: 'fincra-ref',
+          id: 'fincra-transaction'
+        }
+      })
+    );
+
+    const result = await provider.initializePayment({
+      amount: 150.75,
+      currency: 'USD',
+      metadata: {
+        email: 'donor@example.com',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        callbackUrl: 'https://example.com/fincra-callback',
+        country: 'NG',
+        reference: 'fincra-ref'
+      }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.fincra.com/checkout/payments',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'api-key': 'fincra-secret',
+          'Content-Type': 'application/json'
+        })
+      })
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      amount: '150.75',
+      currency: 'USD',
+      reference: 'fincra-ref',
+      redirectUrl: 'https://example.com/fincra-callback',
+      customer: { firstName: 'Jane', lastName: 'Doe', email: 'donor@example.com' },
+      paymentType: 'card',
+      country: 'NG'
+    });
+
+    expect(result).toMatchObject({
+      reference: 'fincra-ref',
+      transactionId: 'fincra-transaction',
+      status: 'pending',
+      metadata: expect.objectContaining({ authorizationUrl: 'https://fincra.test/checkout' })
+    });
+  });
+
+  it('verifies payments and maps the response', async () => {
+    fetchMock.mockResolvedValue(
+      createResponse({ data: { status: 'successful', id: 'fincra-transaction', transactionId: 'fincra-transaction' } })
+    );
+
+    const result = await provider.verifyPayment({ reference: 'fincra-ref', metadata: {} });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.fincra.com/checkout/payments/fincra-ref',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ 'api-key': 'fincra-secret' })
+      })
+    );
+
+    expect(result.status).toBe('completed');
+    expect(result.transactionId).toBe('fincra-transaction');
+  });
+
+  it('sends refund requests to the correct endpoint', async () => {
+    fetchMock.mockResolvedValue(createResponse({ data: { status: 'success' } }));
+
+    const result = await provider.refund({ reference: 'fincra-ref', amount: 100, metadata: {} });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.fincra.com/transactions/fincra-ref/refund',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'api-key': 'fincra-secret',
+          'Content-Type': 'application/json'
+        })
+      })
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ amount: '100.00' });
+    expect(result.metadata).toHaveProperty('refund');
+  });
+
+  it('throws when Fincra responds with an error', async () => {
+    fetchMock.mockResolvedValue(createResponse({}, { ok: false, status: 500, text: 'server error' }));
+
+    await expect(
+      provider.initializePayment({
+        amount: 100,
+        currency: 'USD',
+        metadata: {
+          email: 'donor@example.com',
+          firstName: 'Jane',
+          lastName: 'Doe',
+          callbackUrl: 'https://example.com/fincra-callback'
+        }
+      })
+    ).rejects.toThrow(/Fincra initialize request failed/);
+  });
+});
+
+describe('StripePaymentProvider', () => {
+  const config = createConfig({ 'application.payments.stripeKey': 'stripe-secret' });
+  const provider = new StripePaymentProvider(config);
+
+  it('initializes Stripe checkout sessions', async () => {
+    fetchMock.mockResolvedValue(
+      createResponse({ id: 'cs_test_123', url: 'https://stripe.test/checkout', payment_intent: 'pi_123' })
+    );
+
+    const result = await provider.initializePayment({
+      amount: 75,
+      currency: 'USD',
+      metadata: {
+        email: 'donor@example.com',
+        successUrl: 'https://example.com/success',
+        cancelUrl: 'https://example.com/cancel',
+        reference: 'stripe-ref'
+      }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.stripe.com/v1/checkout/sessions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer stripe-secret',
+          'Content-Type': 'application/x-www-form-urlencoded'
+        })
+      })
+    );
+
+    const rawBody = fetchMock.mock.calls[0][1]?.body as URLSearchParams | string;
+    const params = new URLSearchParams(rawBody instanceof URLSearchParams ? rawBody.toString() : String(rawBody));
+    expect(params.get('client_reference_id')).toBe('stripe-ref');
+    expect(params.get('customer_email')).toBe('donor@example.com');
+    expect(params.get("line_items[0][price_data][unit_amount]")).toBe('7500');
+
+    expect(result).toMatchObject({
+      reference: 'cs_test_123',
+      transactionId: 'pi_123',
+      status: 'pending',
+      metadata: expect.objectContaining({ authorizationUrl: 'https://stripe.test/checkout' })
+    });
+  });
+
+  it('verifies Stripe sessions', async () => {
+    fetchMock.mockResolvedValue(createResponse({ payment_status: 'paid', payment_intent: 'pi_123' }));
+
+    const result = await provider.verifyPayment({ reference: 'cs_test_123', metadata: {} });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.stripe.com/v1/checkout/sessions/cs_test_123',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Authorization: 'Bearer stripe-secret' })
+      })
+    );
+
+    expect(result.status).toBe('completed');
+    expect(result.transactionId).toBe('pi_123');
+  });
+
+  it('issues Stripe refunds using the payment intent', async () => {
+    fetchMock.mockResolvedValue(createResponse({ id: 're_123', status: 'succeeded' }));
+
+    const result = await provider.refund({ reference: 'pi_123', amount: 75, metadata: {} });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.stripe.com/v1/refunds',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer stripe-secret',
+          'Content-Type': 'application/x-www-form-urlencoded'
+        })
+      })
+    );
+
+    const rawBody = fetchMock.mock.calls[0][1]?.body as URLSearchParams | string;
+    const params = new URLSearchParams(rawBody instanceof URLSearchParams ? rawBody.toString() : String(rawBody));
+    expect(params.get('payment_intent')).toBe('pi_123');
+    expect(params.get('amount')).toBe('7500');
+    expect(result.metadata).toHaveProperty('refund');
+  });
+
+  it('throws when Stripe returns an error', async () => {
+    fetchMock.mockResolvedValue(createResponse({}, { ok: false, status: 401, text: 'unauthorized' }));
+
+    await expect(
+      provider.initializePayment({
+        amount: 10,
+        currency: 'USD',
+        metadata: {
+          email: 'donor@example.com',
+          successUrl: 'https://example.com/success',
+          cancelUrl: 'https://example.com/cancel'
+        }
+      })
+    ).rejects.toThrow(/Stripe initialize request failed/);
+  });
+});
+
+describe('FlutterwavePaymentProvider', () => {
+  const config = createConfig({ 'application.payments.flutterwaveKey': 'flutterwave-secret' });
+  const provider = new FlutterwavePaymentProvider(config);
+
+  it('initializes Flutterwave payments', async () => {
+    fetchMock.mockResolvedValue(
+      createResponse({
+        data: {
+          link: 'https://flutterwave.test/checkout',
+          tx_ref: 'flutterwave-ref',
+          id: 'flutterwave-transaction'
+        }
+      })
+    );
+
+    const result = await provider.initializePayment({
+      amount: 200,
+      currency: 'NGN',
+      metadata: {
+        email: 'donor@example.com',
+        callbackUrl: 'https://example.com/flutterwave-callback',
+        reference: 'flutterwave-ref'
+      }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.flutterwave.com/v3/payments',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer flutterwave-secret',
+          'Content-Type': 'application/json'
+        })
+      })
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      tx_ref: 'flutterwave-ref',
+      amount: '200.00',
+      currency: 'NGN',
+      redirect_url: 'https://example.com/flutterwave-callback',
+      customer: { email: 'donor@example.com' }
+    });
+
+    expect(result).toMatchObject({
+      reference: 'flutterwave-ref',
+      transactionId: 'flutterwave-transaction',
+      status: 'pending',
+      metadata: expect.objectContaining({ authorizationUrl: 'https://flutterwave.test/checkout' })
+    });
+  });
+
+  it('verifies Flutterwave transactions', async () => {
+    fetchMock.mockResolvedValue(createResponse({ data: { status: 'successful', id: 'flutterwave-transaction' } }));
+
+    const result = await provider.verifyPayment({ reference: 'flutterwave-ref', metadata: {} });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.flutterwave.com/v3/transactions/flutterwave-ref/verify',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Authorization: 'Bearer flutterwave-secret' })
+      })
+    );
+
+    expect(result.status).toBe('completed');
+    expect(result.transactionId).toBe('flutterwave-transaction');
+  });
+
+  it('issues Flutterwave refunds', async () => {
+    fetchMock.mockResolvedValue(createResponse({ data: { status: 'success' } }));
+
+    const result = await provider.refund({ reference: 'flutterwave-ref', amount: 200, metadata: {} });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.flutterwave.com/v3/transactions/flutterwave-ref/refund',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer flutterwave-secret',
+          'Content-Type': 'application/json'
+        })
+      })
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ amount: '200.00' });
+    expect(result.metadata).toHaveProperty('refund');
+  });
+
+  it('throws when Flutterwave returns an error', async () => {
+    fetchMock.mockResolvedValue(createResponse({}, { ok: false, status: 502, text: 'bad gateway' }));
+
+    await expect(
+      provider.initializePayment({
+        amount: 200,
+        currency: 'NGN',
+        metadata: {
+          email: 'donor@example.com',
+          callbackUrl: 'https://example.com/flutterwave-callback'
+        }
+      })
+    ).rejects.toThrow(/Flutterwave initialize request failed/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared donation payment provider interface with Paystack, Fincra, Stripe, and Flutterwave adapters
- wire the donation service to delegate initialization, verification, and refund flows to the adapters
- cover the adapters with Vitest unit tests that exercise HTTP payloads and error paths

## Testing
- npm test *(fails: missing `jose` dependency and `psql` client required by existing integration suites)*
- npx vitest run test/donation.providers.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d135577660833393569cea38d79767