### PR TITLE
Create Next.js admin console with Playwright coverage

### DIFF
--- a/apps/frontend/app/admin/_components/admin-nav.tsx
+++ b/apps/frontend/app/admin/_components/admin-nav.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const NAV_ITEMS = [
+  { href: '/admin', label: 'Dashboard' },
+  { href: '/admin/users', label: 'Users' },
+  { href: '/admin/care', label: 'Care follow-up' },
+  { href: '/admin/reports/metrics', label: 'Reporting API', external: true }
+] as const;
+
+export default function AdminNav(): JSX.Element {
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Admin navigation" className="space-y-1">
+      {NAV_ITEMS.map((item) => {
+        const isActive = item.external
+          ? false
+          : pathname === item.href || pathname?.startsWith(`${item.href}/`);
+        const baseClasses =
+          'flex items-center justify-between rounded-xl px-4 py-2 text-sm font-medium transition';
+        const activeClasses = isActive
+          ? 'bg-indigo-50 text-indigo-600'
+          : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900';
+
+        if (item.external) {
+          return (
+            <a
+              key={item.href}
+              className={`${baseClasses} ${activeClasses}`}
+              href={item.href}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span>{item.label}</span>
+              <span aria-hidden className="text-xs text-slate-400">
+                ↗
+              </span>
+            </a>
+          );
+        }
+
+        return (
+          <Link key={item.href} className={`${baseClasses} ${activeClasses}`} href={item.href}>
+            <span>{item.label}</span>
+            {isActive ? (
+              <span className="text-xs uppercase tracking-widest text-indigo-500">Active</span>
+            ) : null}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/frontend/app/admin/_components/assimilation-panel.tsx
+++ b/apps/frontend/app/admin/_components/assimilation-panel.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import type { AssimilationReport } from '../../../lib/admin-api';
+
+type AssimilationPanelProps = {
+  report: AssimilationReport;
+};
+
+export default function AssimilationPanel({ report }: AssimilationPanelProps): JSX.Element {
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-sm">
+      <header className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Assimilation funnel</h2>
+          <p className="text-sm text-slate-500">Movement from guest to serving members.</p>
+        </div>
+        <p className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+          {report.totalMembers.toLocaleString()} tracked
+        </p>
+      </header>
+
+      <ul className="mt-6 grid gap-3 sm:grid-cols-2">
+        {report.stages.map((stage) => (
+          <li key={stage.label} className="rounded-xl border border-slate-100 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">{stage.label}</p>
+            <p className="mt-2 text-2xl font-semibold text-slate-900">{stage.count.toLocaleString()}</p>
+          </li>
+        ))}
+        {!report.stages.length ? (
+          <li className="rounded-xl border border-dashed border-slate-200 p-4 text-sm text-slate-500">
+            No members recorded during this period.
+          </li>
+        ) : null}
+      </ul>
+
+      {report.campuses.length ? (
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full text-left text-xs text-slate-600">
+            <thead className="text-slate-400">
+              <tr>
+                <th className="py-2 pr-4 font-medium">Campus</th>
+                {report.stages.map((stage) => (
+                  <th key={stage.label} className="py-2 pr-4 font-medium">
+                    {stage.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {report.campuses.map((campus) => (
+                <tr key={campus.campus} className="border-t border-slate-100">
+                  <td className="py-2 pr-4 font-medium text-slate-900">{campus.campus}</td>
+                  {report.stages.map((stage) => {
+                    const campusStage = campus.stages.find((item) => item.label === stage.label);
+                    return (
+                      <td key={`${campus.campus}-${stage.label}`} className="py-2 pr-4">
+                        {campusStage ? campusStage.count.toLocaleString() : '0'}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="mt-6 text-sm text-slate-500">No campus segmentation available for this range.</p>
+      )}
+    </section>
+  );
+}

--- a/apps/frontend/app/admin/_components/attendance-panel.tsx
+++ b/apps/frontend/app/admin/_components/attendance-panel.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+
+import type { AttendanceReport } from '../../../lib/admin-api';
+
+type AttendancePanelProps = {
+  report: AttendanceReport;
+};
+
+const formatNumber = (value: number): string => value.toLocaleString();
+
+export default function AttendancePanel({ report }: AttendancePanelProps): JSX.Element {
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-sm">
+      <header className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Attendance trends</h2>
+          <p className="text-sm text-slate-500">Segmented by campus and ministry.</p>
+        </div>
+        <p className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-indigo-600">
+          {report.attendanceRate.toFixed(1)}% overall
+        </p>
+      </header>
+
+      <dl className="mt-6 grid gap-4 text-sm text-slate-600 sm:grid-cols-3">
+        <div className="rounded-xl border border-slate-100 p-4">
+          <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">Expected check-ins</dt>
+          <dd className="mt-2 text-2xl font-semibold text-slate-900">{formatNumber(report.totalExpected)}</dd>
+        </div>
+        <div className="rounded-xl border border-slate-100 p-4">
+          <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">Actual check-ins</dt>
+          <dd className="mt-2 text-2xl font-semibold text-slate-900">{formatNumber(report.totalChecked)}</dd>
+        </div>
+        <div className="rounded-xl border border-slate-100 p-4">
+          <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">Gap</dt>
+          <dd className="mt-2 text-2xl font-semibold text-rose-600">
+            {formatNumber(Math.max(report.totalExpected - report.totalChecked, 0))}
+          </dd>
+        </div>
+      </dl>
+
+      {report.campuses.length ? (
+        <div className="mt-6 space-y-4">
+          {report.campuses.map((campus) => (
+            <article key={campus.campus} className="rounded-xl border border-slate-100 p-4">
+              <header className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h3 className="text-base font-semibold text-slate-900">{campus.campus}</h3>
+                  <p className="text-xs text-slate-500">
+                    {formatNumber(campus.checked)} attended · {formatNumber(campus.expected)} expected
+                  </p>
+                </div>
+                <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-600">
+                  {campus.attendanceRate.toFixed(1)}% attendance
+                </span>
+              </header>
+
+              {campus.timeline.length ? (
+                <div className="mt-4 overflow-x-auto">
+                  <table className="min-w-full text-left text-xs text-slate-600">
+                    <thead>
+                      <tr className="text-slate-400">
+                        <th className="py-2 pr-4 font-medium">Date</th>
+                        <th className="py-2 pr-4 font-medium">Checked-in</th>
+                        <th className="py-2 font-medium">Expected</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {campus.timeline.map((entry) => (
+                        <tr key={`${campus.campus}-${entry.date}`} className="border-t border-slate-100">
+                          <td className="py-2 pr-4">{entry.date}</td>
+                          <td className="py-2 pr-4">{formatNumber(entry.checked)}</td>
+                          <td className="py-2">{formatNumber(entry.expected)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : null}
+
+              {campus.departments.length ? (
+                <div className="mt-4">
+                  <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Departments</h4>
+                  <ul className="mt-2 grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+                    {campus.departments.map((department) => (
+                      <li key={`${campus.campus}-${department.name}`} className="rounded-lg border border-slate-100 px-3 py-2">
+                        <p className="font-medium text-slate-900">{department.name}</p>
+                        <p className="text-xs text-slate-500">
+                          {formatNumber(department.checked)} of {formatNumber(department.expected)} attendees
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-6 text-sm text-slate-500">No attendance records available for this reporting window.</p>
+      )}
+    </section>
+  );
+}

--- a/apps/frontend/app/admin/_components/care-follow-up-list.tsx
+++ b/apps/frontend/app/admin/_components/care-follow-up-list.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import type { CareFollowUp } from '../../../lib/admin-api';
+
+type CareFollowUpListProps = {
+  items: CareFollowUp[];
+  heading?: string;
+  description?: string;
+};
+
+const formatDate = (iso: string): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return iso;
+  }
+  return date.toLocaleDateString(undefined, { dateStyle: 'medium' });
+};
+
+const formatInteractionType = (value: string): string =>
+  value
+    .split('_')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+
+export default function CareFollowUpList({
+  items,
+  heading = 'Recent care follow-up',
+  description = 'Latest pastoral touchpoints and outstanding follow-ups.'
+}: CareFollowUpListProps): JSX.Element {
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-sm">
+      <header className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">{heading}</h2>
+          <p className="text-sm text-slate-500">{description}</p>
+        </div>
+        <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+          {items.length} records
+        </span>
+      </header>
+
+      {items.length ? (
+        <ul className="mt-6 space-y-3">
+          {items.map((item) => (
+            <li key={item.id} className="rounded-xl border border-slate-100 p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-slate-900">{item.memberName}</p>
+                  <p className="text-xs text-slate-500">
+                    {formatInteractionType(item.interactionType)} · {formatDate(item.interactionDate)}
+                  </p>
+                </div>
+                {item.followUpRequired ? (
+                  <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-700">
+                    Follow-up required
+                    {item.followUpDate ? ` · ${formatDate(item.followUpDate)}` : null}
+                  </span>
+                ) : null}
+              </div>
+              {item.notes ? <p className="mt-3 text-sm text-slate-600">{item.notes}</p> : null}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-6 text-sm text-slate-500">No follow-up activity recorded for this timeframe.</p>
+      )}
+    </section>
+  );
+}

--- a/apps/frontend/app/admin/_components/giving-panel.tsx
+++ b/apps/frontend/app/admin/_components/giving-panel.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import type { GivingSummary } from '../../../lib/admin-api';
+
+type GivingPanelProps = {
+  summary: GivingSummary;
+};
+
+const formatCurrency = (amount: number, currency = 'USD'): string =>
+  new Intl.NumberFormat(undefined, { style: 'currency', currency, maximumFractionDigits: 0 }).format(amount);
+
+export default function GivingPanel({ summary }: GivingPanelProps): JSX.Element {
+  const primaryCurrency = Object.keys(summary.byCurrency)[0] ?? 'USD';
+
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-sm">
+      <header className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Giving summary</h2>
+          <p className="text-sm text-slate-500">Financial health across payment channels.</p>
+        </div>
+        <p className="text-2xl font-semibold text-slate-900">{formatCurrency(summary.total, primaryCurrency)}</p>
+      </header>
+
+      <div className="mt-6 grid gap-6 text-sm text-slate-600 md:grid-cols-2">
+        <article>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400">By currency</h3>
+          <ul className="mt-2 space-y-2">
+            {Object.entries(summary.byCurrency).map(([currency, amount]) => (
+              <li key={currency} className="flex items-center justify-between rounded-xl border border-slate-100 px-3 py-2">
+                <span className="font-medium text-slate-900">{currency}</span>
+                <span>{formatCurrency(amount, currency)}</span>
+              </li>
+            ))}
+            {!Object.keys(summary.byCurrency).length ? (
+              <li className="text-xs text-slate-500">No completed donations yet.</li>
+            ) : null}
+          </ul>
+        </article>
+
+        <article>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400">By payment method</h3>
+          <ul className="mt-2 space-y-2">
+            {Object.entries(summary.byMethod).map(([method, amount]) => (
+              <li key={method} className="flex items-center justify-between rounded-xl border border-slate-100 px-3 py-2">
+                <span className="capitalize text-slate-900">{method}</span>
+                <span>{formatCurrency(amount, primaryCurrency)}</span>
+              </li>
+            ))}
+            {!Object.keys(summary.byMethod).length ? (
+              <li className="text-xs text-slate-500">No payment channels configured.</li>
+            ) : null}
+          </ul>
+        </article>
+      </div>
+
+      <div className="mt-6">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Monthly totals</h3>
+        {summary.monthly.length ? (
+          <ul className="mt-2 space-y-2 text-sm text-slate-600">
+            {summary.monthly.map((entry) => (
+              <li key={entry.month} className="flex items-center justify-between rounded-xl border border-slate-100 px-3 py-2">
+                <span>{entry.month}</span>
+                <span>{formatCurrency(entry.amount, primaryCurrency)}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-2 text-xs text-slate-500">No giving activity captured for this period.</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/app/admin/_components/time-range-filter.tsx
+++ b/apps/frontend/app/admin/_components/time-range-filter.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const RANGE_OPTIONS = [
+  { value: '30d', label: 'Last 30 days' },
+  { value: '60d', label: 'Last 60 days' },
+  { value: '90d', label: 'Last 90 days' },
+  { value: '6m', label: 'Last 6 months' },
+  { value: '1y', label: 'Last 12 months' }
+] as const;
+
+type TimeRangeFilterProps = {
+  selected?: string;
+};
+
+export default function TimeRangeFilter({ selected }: TimeRangeFilterProps): JSX.Element {
+  return (
+    <form className="flex flex-wrap items-end gap-3" method="get">
+      <label className="flex flex-col text-sm font-medium text-slate-700">
+        <span>Reporting window</span>
+        <select
+          className="mt-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          defaultValue={selected ?? '90d'}
+          name="range"
+        >
+          {RANGE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button
+        className="inline-flex items-center rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+        type="submit"
+      >
+        Apply
+      </button>
+    </form>
+  );
+}

--- a/apps/frontend/app/admin/_components/volunteer-panel.tsx
+++ b/apps/frontend/app/admin/_components/volunteer-panel.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import type { VolunteerReport } from '../../../lib/admin-api';
+
+type VolunteerPanelProps = {
+  report: VolunteerReport;
+};
+
+const formatPercent = (value: number): string => `${value.toFixed(1)}%`;
+
+export default function VolunteerPanel({ report }: VolunteerPanelProps): JSX.Element {
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-sm">
+      <header className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Volunteer fulfilment</h2>
+          <p className="text-sm text-slate-500">Track coverage across departments and roles.</p>
+        </div>
+        <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-600">
+          {formatPercent(report.overallRate)} filled
+        </span>
+      </header>
+
+      <div className="mt-6 grid gap-4 text-sm text-slate-600 sm:grid-cols-2">
+        {report.departments.map((department) => (
+          <article key={department.department} className="rounded-xl border border-slate-100 p-4">
+            <h3 className="text-base font-semibold text-slate-900">{department.department}</h3>
+            <p className="mt-1 text-xs text-slate-500">
+              {department.assigned} of {department.needed} volunteers scheduled
+            </p>
+            <div className="mt-3 h-2 rounded-full bg-slate-100">
+              <div
+                className="h-2 rounded-full bg-indigo-500"
+                style={{ width: `${Math.min(department.rate, 100)}%` }}
+              />
+            </div>
+            <p className="mt-2 text-xs font-semibold text-indigo-600">{formatPercent(department.rate)} coverage</p>
+          </article>
+        ))}
+      </div>
+
+      {report.roles.length ? (
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full text-left text-xs text-slate-600">
+            <thead className="text-slate-400">
+              <tr>
+                <th className="py-2 pr-4 font-medium">Department</th>
+                <th className="py-2 pr-4 font-medium">Role</th>
+                <th className="py-2 pr-4 font-medium">Assigned</th>
+                <th className="py-2 pr-4 font-medium">Needed</th>
+                <th className="py-2 font-medium">Fill rate</th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.roles.map((role) => (
+                <tr key={`${role.department}-${role.role}`} className="border-t border-slate-100">
+                  <td className="py-2 pr-4">{role.department}</td>
+                  <td className="py-2 pr-4">{role.role}</td>
+                  <td className="py-2 pr-4">{role.assigned}</td>
+                  <td className="py-2 pr-4">{role.needed}</td>
+                  <td className="py-2">{formatPercent(role.rate)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="mt-6 text-sm text-slate-500">No volunteer assignments recorded for this range.</p>
+      )}
+    </section>
+  );
+}

--- a/apps/frontend/app/admin/care/page.tsx
+++ b/apps/frontend/app/admin/care/page.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import type { CareFollowUp } from '../../../lib/admin-api';
+import { getRecentCareFollowUps } from '../../../lib/admin-api';
+import CareFollowUpList from '../_components/care-follow-up-list';
+
+async function loadCareFollowUps(): Promise<CareFollowUp[]> {
+  try {
+    return await getRecentCareFollowUps(25);
+  } catch (error) {
+    console.error('Unable to load care follow-up records.', error);
+    return [];
+  }
+}
+
+export default async function CareFollowUpPage(): Promise<JSX.Element> {
+  const items = await loadCareFollowUps();
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-2xl bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-semibold text-slate-900">Care follow-up</h1>
+        <p className="mt-2 text-sm text-slate-500">
+          Review recent pastoral touchpoints, confirm next steps, and coordinate ministry outreach. Once the Prisma mutation
+          endpoints are live, this page will support completing follow-ups, rescheduling, and escalating tasks.
+        </p>
+        <div className="mt-4 rounded-xl border border-indigo-200 bg-indigo-50 p-4 text-xs text-indigo-700">
+          Tip: keep the Flask dashboard open while we finish the Next.js migration so you can cross-reference long-form member
+          profiles.
+        </div>
+      </section>
+
+      <CareFollowUpList
+        description="The API returns the latest interactions first. Optimistic updates will slot in once mutations are available."
+        heading="Pastoral interactions"
+        items={items}
+      />
+    </div>
+  );
+}

--- a/apps/frontend/app/admin/layout.tsx
+++ b/apps/frontend/app/admin/layout.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { Metadata } from 'next';
+
+import AdminNav from './_components/admin-nav';
+
+export const metadata: Metadata = {
+  title: 'Admin | Covenant Connect',
+  description: 'Secure dashboards and workflows for Covenant Connect administrators.'
+};
+
+type AdminLayoutProps = {
+  children: React.ReactNode;
+};
+
+export default function AdminLayout({ children }: AdminLayoutProps): JSX.Element {
+  return (
+    <div className="bg-slate-50 py-12">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 lg:flex-row">
+        <aside className="lg:w-64">
+          <div className="rounded-2xl bg-white p-6 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-widest text-indigo-500">Admin console</p>
+            <h1 className="mt-2 text-xl font-semibold text-slate-900">Leadership tools</h1>
+            <p className="mt-2 text-sm text-slate-500">
+              Authenticate against the Nest/Prisma services before running production workflows. Demo data is safe to explore.
+            </p>
+            <div className="mt-6">
+              <AdminNav />
+            </div>
+          </div>
+        </aside>
+        <main className="flex-1 space-y-8">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/app/admin/page.tsx
+++ b/apps/frontend/app/admin/page.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+
+import type { AdminMetrics, CareFollowUp } from '../../lib/admin-api';
+import { getAdminMetrics, getRecentCareFollowUps } from '../../lib/admin-api';
+import AssimilationPanel from './_components/assimilation-panel';
+import AttendancePanel from './_components/attendance-panel';
+import CareFollowUpList from './_components/care-follow-up-list';
+import GivingPanel from './_components/giving-panel';
+import TimeRangeFilter from './_components/time-range-filter';
+import VolunteerPanel from './_components/volunteer-panel';
+
+const DEFAULT_RANGE = '90d';
+const RANGE_LABELS: Record<string, string> = {
+  '30d': 'Last 30 days',
+  '60d': 'Last 60 days',
+  '90d': 'Last 90 days',
+  '6m': 'Last 6 months',
+  '1y': 'Last 12 months'
+};
+
+const createEmptyMetrics = (): AdminMetrics => ({
+  attendance: {
+    totalExpected: 0,
+    totalChecked: 0,
+    attendanceRate: 0,
+    campuses: []
+  },
+  volunteers: {
+    roles: [],
+    departments: [],
+    overallRate: 0
+  },
+  giving: {
+    total: 0,
+    byCurrency: {},
+    byMethod: {},
+    monthly: []
+  },
+  assimilation: {
+    totalMembers: 0,
+    stages: [],
+    campuses: []
+  }
+});
+
+type DashboardData = {
+  metrics: AdminMetrics;
+  followUps: CareFollowUp[];
+  error?: string;
+};
+
+async function loadDashboard(range: string): Promise<DashboardData> {
+  try {
+    const [metrics, followUps] = await Promise.all([
+      getAdminMetrics(range),
+      getRecentCareFollowUps(8)
+    ]);
+
+    return { metrics, followUps };
+  } catch (error) {
+    console.error('Failed to load admin dashboard data.', error);
+    return {
+      metrics: createEmptyMetrics(),
+      followUps: [],
+      error:
+        'The Prisma API is unavailable right now. The dashboard is showing placeholder data until the connection is restored.'
+    };
+  }
+}
+
+type AdminDashboardPageProps = {
+  searchParams?: Record<string, string | string[]>;
+};
+
+export default async function AdminDashboardPage({
+  searchParams
+}: AdminDashboardPageProps): Promise<JSX.Element> {
+  const rangeParam = typeof searchParams?.range === 'string' ? searchParams.range : DEFAULT_RANGE;
+  const { metrics, followUps, error } = await loadDashboard(rangeParam);
+  const rangeLabel = RANGE_LABELS[rangeParam] ?? RANGE_LABELS[DEFAULT_RANGE];
+
+  return (
+    <div className="space-y-8">
+      <header className="rounded-2xl bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-semibold text-slate-900">Executive insights</h1>
+        <p className="mt-2 text-sm text-slate-500">
+          Monitor attendance, assimilation, volunteer coverage, and giving in one place. All data flows through the forthcoming
+          Prisma-backed admin APIs.
+        </p>
+        <div className="mt-6 flex flex-wrap items-center justify-between gap-6">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Current window</p>
+            <p className="text-sm font-medium text-slate-900">{rangeLabel}</p>
+          </div>
+          <TimeRangeFilter selected={rangeParam} />
+        </div>
+        {error ? (
+          <div className="mt-6 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+            {error}
+          </div>
+        ) : null}
+      </header>
+
+      <div className="grid gap-8 lg:grid-cols-[2fr_1fr]">
+        <AttendancePanel report={metrics.attendance} />
+        <AssimilationPanel report={metrics.assimilation} />
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-2">
+        <VolunteerPanel report={metrics.volunteers} />
+        <GivingPanel summary={metrics.giving} />
+      </div>
+
+      <CareFollowUpList items={followUps} />
+    </div>
+  );
+}

--- a/apps/frontend/app/admin/users/actions.ts
+++ b/apps/frontend/app/admin/users/actions.ts
@@ -1,0 +1,51 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import type {
+  AdminUserRecord,
+  CreateAdminUserInput,
+  UpdateAdminUserInput
+} from '../../../lib/admin-api';
+import { createAdminUser, deleteAdminUser, updateAdminUser } from '../../../lib/admin-api';
+
+export type UserActionResult =
+  | { status: 'success'; user?: AdminUserRecord }
+  | { status: 'deleted' }
+  | { status: 'error'; message: string };
+
+const GENERIC_ERROR =
+  'The admin API did not respond. Please verify the Nest/Prisma service is running and try again.';
+
+export async function createUserAction(input: CreateAdminUserInput): Promise<UserActionResult> {
+  try {
+    const user = await createAdminUser(input);
+    revalidatePath('/admin/users');
+    return { status: 'success', user };
+  } catch (error) {
+    console.error('Failed to create admin user.', error);
+    return { status: 'error', message: GENERIC_ERROR };
+  }
+}
+
+export async function updateUserAction(input: UpdateAdminUserInput): Promise<UserActionResult> {
+  try {
+    const user = await updateAdminUser(input);
+    revalidatePath('/admin/users');
+    return { status: 'success', user };
+  } catch (error) {
+    console.error('Failed to update admin user.', error);
+    return { status: 'error', message: GENERIC_ERROR };
+  }
+}
+
+export async function deleteUserAction(id: string): Promise<UserActionResult> {
+  try {
+    await deleteAdminUser(id);
+    revalidatePath('/admin/users');
+    return { status: 'deleted' };
+  } catch (error) {
+    console.error('Failed to delete admin user.', error);
+    return { status: 'error', message: GENERIC_ERROR };
+  }
+}

--- a/apps/frontend/app/admin/users/page.tsx
+++ b/apps/frontend/app/admin/users/page.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import type { AdminUserRecord } from '../../../lib/admin-api';
+import { getAdminUsers } from '../../../lib/admin-api';
+import UserManagement from './user-management';
+
+async function loadUsers(): Promise<AdminUserRecord[]> {
+  try {
+    const response = await getAdminUsers();
+    return response.users;
+  } catch (error) {
+    console.error('Unable to load admin users.', error);
+    return [];
+  }
+}
+
+export default async function AdminUsersPage(): Promise<JSX.Element> {
+  const users = await loadUsers();
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-2xl bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-semibold text-slate-900">User management</h1>
+        <p className="mt-2 text-sm text-slate-500">
+          Manage staff accounts, promote admins, and prepare for the upcoming Prisma-based authentication rollout. All
+          mutations optimistically update the table and surface clear error states if the API is offline.
+        </p>
+      </section>
+
+      <UserManagement initialUsers={users} />
+    </div>
+  );
+}

--- a/apps/frontend/app/admin/users/user-management.tsx
+++ b/apps/frontend/app/admin/users/user-management.tsx
@@ -1,0 +1,375 @@
+'use client';
+
+import React, { useMemo, useState, useTransition } from 'react';
+
+import type { AdminUserRecord } from '../../../lib/admin-api';
+import { createUserAction, deleteUserAction, updateUserAction } from './actions';
+
+const sortUsers = (list: AdminUserRecord[]): AdminUserRecord[] =>
+  [...list].sort((a, b) => a.username.localeCompare(b.username, undefined, { sensitivity: 'base' }));
+
+type Feedback = {
+  type: 'success' | 'error' | 'info';
+  text: string;
+};
+
+type UserManagementProps = {
+  initialUsers: AdminUserRecord[];
+};
+
+type EditFormState = {
+  username: string;
+  email: string;
+  password: string;
+  isAdmin: boolean;
+};
+
+const emptyEditForm: EditFormState = {
+  username: '',
+  email: '',
+  password: '',
+  isAdmin: false
+};
+
+export default function UserManagement({ initialUsers }: UserManagementProps): JSX.Element {
+  const [users, setUsers] = useState<AdminUserRecord[]>(() => sortUsers(initialUsers));
+  const [message, setMessage] = useState<Feedback | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [editingUser, setEditingUser] = useState<AdminUserRecord | null>(null);
+  const [editForm, setEditForm] = useState<EditFormState>(emptyEditForm);
+
+  const totalAdmins = useMemo(() => users.filter((user) => user.isAdmin).length, [users]);
+
+  const handleCreateSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const payload = {
+      username: String(formData.get('username') ?? '').trim(),
+      email: String(formData.get('email') ?? '').trim(),
+      password: String(formData.get('password') ?? ''),
+      isAdmin: formData.get('isAdmin') === 'on'
+    };
+
+    if (!payload.username || !payload.email || !payload.password) {
+      setMessage({ type: 'error', text: 'Username, email, and password are required.' });
+      return;
+    }
+
+    const optimisticUser: AdminUserRecord = {
+      id: `temp-${Date.now()}`,
+      username: payload.username,
+      email: payload.email,
+      isAdmin: payload.isAdmin,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      lastLoginAt: null
+    };
+
+    setUsers((prev) => sortUsers([...prev, optimisticUser]));
+    setMessage({ type: 'info', text: 'Creating user…' });
+    form.reset();
+
+    startTransition(async () => {
+      const result = await createUserAction(payload);
+      if (result.status === 'success' && result.user) {
+        const createdUser = result.user;
+        setUsers((prev) => sortUsers(prev.map((user) => (user.id === optimisticUser.id ? createdUser : user))));
+        setMessage({ type: 'success', text: `Created ${createdUser.username}.` });
+      } else {
+        setUsers((prev) => prev.filter((user) => user.id !== optimisticUser.id));
+        setMessage({ type: 'error', text: result.status === 'error' ? result.message : 'Unable to create user.' });
+      }
+    });
+  };
+
+  const startEditing = (user: AdminUserRecord) => {
+    setEditingUser(user);
+    setEditForm({ username: user.username, email: user.email, password: '', isAdmin: user.isAdmin });
+    setMessage(null);
+  };
+
+  const cancelEditing = () => {
+    setEditingUser(null);
+    setEditForm(emptyEditForm);
+  };
+
+  const handleEditChange = (key: keyof EditFormState, value: string | boolean) => {
+    setEditForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleUpdateSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+    if (!editingUser) {
+      return;
+    }
+
+    if (!editForm.username.trim() || !editForm.email.trim()) {
+      setMessage({ type: 'error', text: 'Username and email are required.' });
+      return;
+    }
+
+    const payload = {
+      id: editingUser.id,
+      username: editForm.username.trim(),
+      email: editForm.email.trim(),
+      password: editForm.password.trim() || undefined,
+      isAdmin: editForm.isAdmin
+    };
+
+    const originalUser = editingUser;
+    const optimisticUser: AdminUserRecord = {
+      ...editingUser,
+      username: payload.username,
+      email: payload.email,
+      isAdmin: payload.isAdmin,
+      updatedAt: new Date().toISOString()
+    };
+
+    setUsers((prev) => sortUsers(prev.map((user) => (user.id === originalUser.id ? optimisticUser : user))));
+    setMessage({ type: 'info', text: 'Saving changes…' });
+
+    startTransition(async () => {
+      const result = await updateUserAction(payload);
+      if (result.status === 'success' && result.user) {
+        const savedUser = result.user;
+        setUsers((prev) => sortUsers(prev.map((user) => (user.id === originalUser.id ? savedUser : user))));
+        setEditingUser(savedUser);
+        setEditForm((prevState) => ({ ...prevState, password: '' }));
+        setMessage({ type: 'success', text: `Updated ${savedUser.username}.` });
+      } else {
+        setUsers((prev) => sortUsers(prev.map((user) => (user.id === originalUser.id ? originalUser : user))));
+        setMessage({ type: 'error', text: result.status === 'error' ? result.message : 'Unable to update user.' });
+      }
+    });
+  };
+
+  const handleDelete = (user: AdminUserRecord) => {
+    const previousUsers = users;
+    setUsers((prev) => prev.filter((existing) => existing.id !== user.id));
+    setMessage({ type: 'info', text: `Removing ${user.username}…` });
+    if (editingUser?.id === user.id) {
+      cancelEditing();
+    }
+
+    startTransition(async () => {
+      const result = await deleteUserAction(user.id);
+      if (result.status === 'deleted') {
+        setMessage({ type: 'success', text: `${user.username} removed.` });
+      } else {
+        setUsers(previousUsers);
+        setMessage({ type: 'error', text: result.status === 'error' ? result.message : 'Unable to delete user.' });
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-8">
+      {message ? (
+        <div
+          aria-live="polite"
+          className={`rounded-xl border px-4 py-3 text-sm ${
+            message.type === 'success'
+              ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+              : message.type === 'error'
+              ? 'border-rose-200 bg-rose-50 text-rose-700'
+              : 'border-indigo-200 bg-indigo-50 text-indigo-700'
+          }`}
+        >
+          {message.text}
+        </div>
+      ) : null}
+
+      <section className="rounded-2xl bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">Invite a new user</h2>
+        <p className="mt-2 text-sm text-slate-500">
+          Accounts are created immediately through the Prisma API. Use the admin toggle for staff who should access reports and
+          automations.
+        </p>
+        <form className="mt-6 grid gap-4 sm:grid-cols-2" onSubmit={handleCreateSubmit}>
+          <label className="flex flex-col text-sm font-medium text-slate-700">
+            Username
+            <input
+              className="mt-1 rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              maxLength={100}
+              name="username"
+              placeholder="e.g. adefemi"
+              required
+              type="text"
+            />
+          </label>
+          <label className="flex flex-col text-sm font-medium text-slate-700">
+            Email
+            <input
+              className="mt-1 rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              name="email"
+              placeholder="team@covenant.cc"
+              required
+              type="email"
+            />
+          </label>
+          <label className="flex flex-col text-sm font-medium text-slate-700">
+            Temporary password
+            <input
+              className="mt-1 rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              minLength={8}
+              name="password"
+              placeholder="Send a reset link after creation"
+              required
+              type="password"
+            />
+          </label>
+          <label className="flex items-center gap-2 text-sm font-medium text-slate-700">
+            <input
+              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+              name="isAdmin"
+              type="checkbox"
+            />
+            Grant admin access
+          </label>
+          <div className="sm:col-span-2">
+            <button
+              className="inline-flex items-center rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-70"
+              disabled={isPending}
+              type="submit"
+            >
+              Create user
+            </button>
+          </div>
+        </form>
+      </section>
+
+      {editingUser ? (
+        <section className="rounded-2xl bg-white p-6 shadow-sm">
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-lg font-semibold text-slate-900">Edit {editingUser.username}</h2>
+            <button
+              className="text-sm font-medium text-slate-500 hover:text-slate-900"
+              onClick={cancelEditing}
+              type="button"
+            >
+              Cancel
+            </button>
+          </div>
+          <form className="mt-6 grid gap-4 sm:grid-cols-2" onSubmit={handleUpdateSubmit}>
+            <label className="flex flex-col text-sm font-medium text-slate-700">
+              Username
+              <input
+                className="mt-1 rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                onChange={(event) => handleEditChange('username', event.target.value)}
+                required
+                type="text"
+                value={editForm.username}
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700">
+              Email
+              <input
+                className="mt-1 rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                onChange={(event) => handleEditChange('email', event.target.value)}
+                required
+                type="email"
+                value={editForm.email}
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-700">
+              New password (optional)
+              <input
+                className="mt-1 rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                onChange={(event) => handleEditChange('password', event.target.value)}
+                placeholder="Leave blank to keep the current password"
+                type="password"
+                value={editForm.password}
+              />
+            </label>
+            <label className="flex items-center gap-2 text-sm font-medium text-slate-700">
+              <input
+                checked={editForm.isAdmin}
+                className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                onChange={(event) => handleEditChange('isAdmin', event.target.checked)}
+                type="checkbox"
+              />
+              Admin access
+            </label>
+            <div className="sm:col-span-2">
+              <button
+                className="inline-flex items-center rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-70"
+                disabled={isPending}
+                type="submit"
+              >
+                Save changes
+              </button>
+            </div>
+          </form>
+        </section>
+      ) : null}
+
+      <section className="rounded-2xl bg-white p-6 shadow-sm">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Team directory</h2>
+            <p className="text-sm text-slate-500">{users.length} users · {totalAdmins} admins</p>
+          </div>
+        </div>
+        {users.length ? (
+          <div className="mt-6 overflow-x-auto">
+            <table className="min-w-full text-left text-sm text-slate-600">
+              <thead className="text-slate-400">
+                <tr>
+                  <th className="py-2 pr-4 font-medium">Name</th>
+                  <th className="py-2 pr-4 font-medium">Email</th>
+                  <th className="py-2 pr-4 font-medium">Role</th>
+                  <th className="py-2 pr-4 font-medium">Updated</th>
+                  <th className="py-2 font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((user) => (
+                  <tr key={user.id} className="border-t border-slate-100">
+                    <td className="py-2 pr-4 font-medium text-slate-900">{user.username}</td>
+                    <td className="py-2 pr-4">{user.email}</td>
+                    <td className="py-2 pr-4">
+                      <span
+                        className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                          user.isAdmin ? 'bg-indigo-50 text-indigo-600' : 'bg-slate-100 text-slate-600'
+                        }`}
+                      >
+                        {user.isAdmin ? 'Admin' : 'User'}
+                      </span>
+                    </td>
+                    <td className="py-2 pr-4 text-xs text-slate-500">
+                      {new Date(user.updatedAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}
+                    </td>
+                    <td className="py-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <button
+                          className="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:border-indigo-200 hover:text-indigo-600"
+                          disabled={isPending}
+                          onClick={() => startEditing(user)}
+                          type="button"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          className="rounded-full border border-rose-200 px-3 py-1 text-xs font-semibold text-rose-600 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          disabled={isPending}
+                          onClick={() => handleDelete(user)}
+                          type="button"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="mt-6 text-sm text-slate-500">No users found. Add your first teammate to get started.</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -39,6 +39,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <Link className="transition hover:text-indigo-600" href="/prayer">
                   Prayer
                 </Link>
+                <Link className="transition hover:text-indigo-600" href="/admin">
+                  Admin
+                </Link>
               </nav>
             </div>
           </header>

--- a/apps/frontend/lib/admin-api.ts
+++ b/apps/frontend/lib/admin-api.ts
@@ -1,0 +1,329 @@
+import { apiRequest } from './api';
+
+export type AttendanceTimelineEntry = {
+  date: string;
+  expected: number;
+  checked: number;
+};
+
+export type AttendanceDepartmentSummary = {
+  name: string;
+  expected: number;
+  checked: number;
+};
+
+export type AttendanceCampusSummary = {
+  campus: string;
+  expected: number;
+  checked: number;
+  attendanceRate: number;
+  timeline: AttendanceTimelineEntry[];
+  departments: AttendanceDepartmentSummary[];
+};
+
+export type AttendanceReport = {
+  totalExpected: number;
+  totalChecked: number;
+  attendanceRate: number;
+  campuses: AttendanceCampusSummary[];
+};
+
+export type VolunteerRoleRow = {
+  department: string;
+  role: string;
+  needed: number;
+  assigned: number;
+  rate: number;
+};
+
+export type VolunteerDepartmentSummary = {
+  department: string;
+  assigned: number;
+  needed: number;
+  rate: number;
+};
+
+export type VolunteerReport = {
+  roles: VolunteerRoleRow[];
+  departments: VolunteerDepartmentSummary[];
+  overallRate: number;
+};
+
+export type GivingMonthlyEntry = {
+  month: string;
+  amount: number;
+};
+
+export type GivingSummary = {
+  total: number;
+  byCurrency: Record<string, number>;
+  byMethod: Record<string, number>;
+  monthly: GivingMonthlyEntry[];
+};
+
+export type AssimilationStage = {
+  label: string;
+  count: number;
+};
+
+export type AssimilationCampus = {
+  campus: string;
+  stages: AssimilationStage[];
+};
+
+export type AssimilationReport = {
+  totalMembers: number;
+  stages: AssimilationStage[];
+  campuses: AssimilationCampus[];
+};
+
+export type AdminMetrics = {
+  attendance: AttendanceReport;
+  volunteers: VolunteerReport;
+  giving: GivingSummary;
+  assimilation: AssimilationReport;
+};
+
+export type CareFollowUp = {
+  id: string;
+  memberName: string;
+  interactionType: string;
+  interactionDate: string;
+  notes?: string;
+  followUpRequired?: boolean;
+  followUpDate?: string | null;
+};
+
+export type AdminUserRecord = {
+  id: string;
+  username: string;
+  email: string;
+  isAdmin: boolean;
+  createdAt: string;
+  updatedAt: string;
+  lastLoginAt?: string | null;
+};
+
+export type AdminUsersResponse = {
+  users: AdminUserRecord[];
+};
+
+export type CreateAdminUserInput = {
+  username: string;
+  email: string;
+  password: string;
+  isAdmin: boolean;
+};
+
+export type UpdateAdminUserInput = {
+  id: string;
+  username?: string;
+  email?: string;
+  password?: string;
+  isAdmin?: boolean;
+};
+
+type MetricsPayload = {
+  attendance: {
+    total_expected: number;
+    total_checked: number;
+    attendance_rate: number;
+    campuses: {
+      campus: string;
+      expected: number;
+      checked: number;
+      attendance_rate: number;
+      timeline: {
+        date: string;
+        expected: number;
+        checked: number;
+      }[];
+      departments: {
+        name: string;
+        expected: number;
+        checked: number;
+      }[];
+    }[];
+  };
+  volunteers: {
+    roles: VolunteerRoleRow[];
+    departments: VolunteerDepartmentSummary[];
+    overall_rate: number;
+  };
+  giving: {
+    total: number;
+    by_currency: Record<string, number>;
+    by_method: Record<string, number>;
+    monthly: GivingMonthlyEntry[];
+  };
+  assimilation: {
+    total_members: number;
+    stages: AssimilationStage[];
+    campuses: {
+      campus: string;
+      stages: AssimilationStage[];
+    }[];
+  };
+};
+
+type CareFollowUpRecord = {
+  id: string | number;
+  member_name?: string | null;
+  interaction_type: string;
+  interaction_date: string;
+  notes?: string | null;
+  follow_up_required?: boolean;
+  follow_up_date?: string | null;
+};
+
+type AdminUserRecordPayload = {
+  id: string | number;
+  username: string;
+  email: string;
+  is_admin: boolean;
+  created_at: string;
+  updated_at: string;
+  last_login_at?: string | null;
+};
+
+const toAttendanceReport = (payload: MetricsPayload['attendance']): AttendanceReport => ({
+  totalExpected: payload.total_expected ?? 0,
+  totalChecked: payload.total_checked ?? 0,
+  attendanceRate: payload.attendance_rate ?? 0,
+  campuses: (payload.campuses ?? []).map((campus) => ({
+    campus: campus.campus,
+    expected: campus.expected ?? 0,
+    checked: campus.checked ?? 0,
+    attendanceRate: campus.attendance_rate ?? 0,
+    timeline: (campus.timeline ?? []).map((entry) => ({
+      date: entry.date,
+      expected: entry.expected ?? 0,
+      checked: entry.checked ?? 0
+    })),
+    departments: (campus.departments ?? []).map((department) => ({
+      name: department.name,
+      expected: department.expected ?? 0,
+      checked: department.checked ?? 0
+    }))
+  }))
+});
+
+const toVolunteerReport = (payload: MetricsPayload['volunteers']): VolunteerReport => ({
+  roles: (payload.roles ?? []).map((role) => ({
+    department: role.department,
+    role: role.role,
+    needed: role.needed ?? 0,
+    assigned: role.assigned ?? 0,
+    rate: role.rate ?? 0
+  })),
+  departments: (payload.departments ?? []).map((department) => ({
+    department: department.department,
+    assigned: department.assigned ?? 0,
+    needed: department.needed ?? 0,
+    rate: department.rate ?? 0
+  })),
+  overallRate: payload.overall_rate ?? 0
+});
+
+const toGivingSummary = (payload: MetricsPayload['giving']): GivingSummary => ({
+  total: payload.total ?? 0,
+  byCurrency: payload.by_currency ?? {},
+  byMethod: payload.by_method ?? {},
+  monthly: (payload.monthly ?? []).map((entry) => ({
+    month: entry.month,
+    amount: entry.amount ?? 0
+  }))
+});
+
+const toAssimilationReport = (payload: MetricsPayload['assimilation']): AssimilationReport => ({
+  totalMembers: payload.total_members ?? 0,
+  stages: (payload.stages ?? []).map((stage) => ({
+    label: stage.label,
+    count: stage.count ?? 0
+  })),
+  campuses: (payload.campuses ?? []).map((campus) => ({
+    campus: campus.campus,
+    stages: (campus.stages ?? []).map((stage) => ({
+      label: stage.label,
+      count: stage.count ?? 0
+    }))
+  }))
+});
+
+const toCareFollowUp = (record: CareFollowUpRecord): CareFollowUp => ({
+  id: String(record.id),
+  memberName: record.member_name?.trim() || 'Unknown member',
+  interactionType: record.interaction_type,
+  interactionDate: record.interaction_date,
+  notes: record.notes ?? undefined,
+  followUpRequired: record.follow_up_required ?? false,
+  followUpDate: record.follow_up_date ?? null
+});
+
+const toAdminUserRecord = (record: AdminUserRecordPayload): AdminUserRecord => ({
+  id: String(record.id),
+  username: record.username,
+  email: record.email,
+  isAdmin: record.is_admin,
+  createdAt: record.created_at,
+  updatedAt: record.updated_at,
+  lastLoginAt: record.last_login_at ?? null
+});
+
+export async function getAdminMetrics(range?: string): Promise<AdminMetrics> {
+  const search = new URLSearchParams();
+  if (range) {
+    search.set('range', range);
+  }
+  const path = search.toString() ? `/admin/reports/metrics?${search.toString()}` : '/admin/reports/metrics';
+  const payload = await apiRequest<MetricsPayload>(path);
+
+  return {
+    attendance: toAttendanceReport(payload.attendance),
+    volunteers: toVolunteerReport(payload.volunteers),
+    giving: toGivingSummary(payload.giving),
+    assimilation: toAssimilationReport(payload.assimilation)
+  };
+}
+
+export async function getRecentCareFollowUps(limit = 10): Promise<CareFollowUp[]> {
+  const search = new URLSearchParams({ limit: String(limit) });
+  const records = await apiRequest<CareFollowUpRecord[]>(`/admin/care/follow-ups?${search.toString()}`);
+  return records.map(toCareFollowUp);
+}
+
+export async function getAdminUsers(): Promise<AdminUsersResponse> {
+  const records = await apiRequest<AdminUserRecordPayload[]>(`/admin/users`);
+  return { users: records.map(toAdminUserRecord) };
+}
+
+export async function createAdminUser(input: CreateAdminUserInput): Promise<AdminUserRecord> {
+  const record = await apiRequest<AdminUserRecordPayload>(`/admin/users`, {
+    method: 'POST',
+    body: JSON.stringify({
+      username: input.username,
+      email: input.email,
+      password: input.password,
+      is_admin: input.isAdmin
+    })
+  });
+  return toAdminUserRecord(record);
+}
+
+export async function updateAdminUser(input: UpdateAdminUserInput): Promise<AdminUserRecord> {
+  const { id, ...rest } = input;
+  const record = await apiRequest<AdminUserRecordPayload>(`/admin/users/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      username: rest.username,
+      email: rest.email,
+      password: rest.password,
+      is_admin: rest.isAdmin
+    })
+  });
+  return toAdminUserRecord(record);
+}
+
+export async function deleteAdminUser(id: string): Promise<void> {
+  await apiRequest(`/admin/users/${id}`, { method: 'DELETE' });
+}

--- a/apps/frontend/lib/api.ts
+++ b/apps/frontend/lib/api.ts
@@ -9,7 +9,7 @@ const normalizeBaseUrl = (input: string | undefined): string => {
   return trimmed.replace(/\/$/, '');
 };
 
-const API_BASE_URL = normalizeBaseUrl(process.env.NEXT_PUBLIC_API_BASE_URL);
+export const API_BASE_URL = normalizeBaseUrl(process.env.NEXT_PUBLIC_API_BASE_URL);
 
 export class ApiError extends Error {
   constructor(
@@ -28,13 +28,17 @@ export class ApiError extends Error {
   }
 }
 
-async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+export async function apiRequest<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const headers = new Headers(init.headers);
+  headers.set('Accept', headers.get('Accept') ?? 'application/json');
+
+  if (init.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+
   const response = await fetch(`${API_BASE_URL}${ensureLeadingSlash(path)}`, {
     ...init,
-    headers: {
-      Accept: 'application/json',
-      ...(init.headers ?? {})
-    },
+    headers,
     cache: init.cache ?? 'no-store'
   });
 
@@ -93,7 +97,6 @@ export type EventSummary = {
 
 export type EventsResponse = PaginatedResponse<EventSummary>;
 
- codex/verify-frontend-and-endpoints-connection-kqvbfr
 export type DonationRecord = {
   id: string;
   memberId: string | null;
@@ -122,17 +125,16 @@ export type PrayerRequestRecord = {
 };
 
 export type PrayerRequestsResponse = PaginatedResponse<PrayerRequestRecord>;
-       main
+
 export async function getDashboardReport(): Promise<DashboardResponse> {
-  return request<DashboardResponse>('/reports/dashboard');
+  return apiRequest<DashboardResponse>('/reports/dashboard');
 }
 
 export async function getHomeContent(): Promise<HomeContentResponse> {
-  return request<HomeContentResponse>('/content/home');
+  return apiRequest<HomeContentResponse>('/content/home');
 }
 
 export async function getUpcomingEvents(limit = 3): Promise<EventsResponse> {
- codex/verify-frontend-and-endpoints-connection-kqvbfr
   return getEvents({ page: 1, pageSize: limit });
 }
 
@@ -144,7 +146,7 @@ export async function getEvents({
   pageSize?: number;
 } = {}): Promise<EventsResponse> {
   const search = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
-  return request<EventsResponse>(`/events?${search.toString()}`);
+  return apiRequest<EventsResponse>(`/events?${search.toString()}`);
 }
 
 export async function getDonations({
@@ -155,16 +157,9 @@ export async function getDonations({
   pageSize?: number;
 } = {}): Promise<DonationsResponse> {
   const search = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
-  return request<DonationsResponse>(`/donations?${search.toString()}`);
+  return apiRequest<DonationsResponse>(`/donations?${search.toString()}`);
 }
 
 export async function getPrayerRequests(): Promise<PrayerRequestsResponse> {
-  return request<PrayerRequestsResponse>('/prayer/requests');
+  return apiRequest<PrayerRequestsResponse>('/prayer/requests');
 }
-
-  const search = new URLSearchParams({ page: '1', pageSize: String(limit) });
-  return request<EventsResponse>(`/events?${search.toString()}`);
-}
-
-     main
-export { API_BASE_URL };

--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
-    appDir: true
+    serverActions: true
   }
 };
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "axios": "^1.6.0",
@@ -16,6 +17,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.39.0",
     "@types/node": "^20.9.0",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000
+  },
+  fullyParallel: true,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:3000',
+    headless: true
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: 120_000
+  }
+});

--- a/apps/frontend/tests/e2e/admin-dashboard.spec.ts
+++ b/apps/frontend/tests/e2e/admin-dashboard.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Admin dashboard', () => {
+  test('renders fallback metrics when the API is offline', async ({ page }) => {
+    await page.goto('/admin');
+
+    await expect(page.getByRole('heading', { name: 'Executive insights' })).toBeVisible();
+    await expect(
+      page.getByText(
+        'The Prisma API is unavailable right now. The dashboard is showing placeholder data until the connection is restored.'
+      )
+    ).toBeVisible();
+
+    await expect(page.getByText('No attendance records available for this reporting window.')).toBeVisible();
+    await expect(page.getByText('No follow-up activity recorded for this timeframe.')).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/e2e/admin-users.spec.ts
+++ b/apps/frontend/tests/e2e/admin-users.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Admin user management', () => {
+  test('shows an error when creating a user without the API', async ({ page }) => {
+    await page.goto('/admin/users');
+
+    await expect(page.getByRole('heading', { name: 'User management' })).toBeVisible();
+
+    await page.getByLabel('Username').fill('playwright-user');
+    await page.getByLabel('Email').fill('playwright@example.com');
+    await page.getByLabel('Temporary password').fill('supersecure123');
+    await page.getByRole('button', { name: 'Create user' }).click();
+
+    await expect(
+      page.getByText('The admin API did not respond. Please verify the Nest/Prisma service is running and try again.')
+    ).toBeVisible();
+
+    await expect(page.getByRole('row', { name: /playwright-user/i })).toHaveCount(0);
+  });
+});

--- a/docs/admin_inventory.md
+++ b/docs/admin_inventory.md
@@ -1,0 +1,44 @@
+# Admin experience inventory
+
+## Blueprint overview
+
+- `routes/admin.py` registers the `admin_bp` blueprint and protects all handlers with `login_required` and a custom `admin_required` guard, exposing dashboard, user management, member care, and prayer moderation views.【F:routes/admin.py†L26-L199】
+- `routes/admin_reports.py` adds the `/admin/reports` blueprint that powers aggregated metrics, CSV exports, and reporting helpers consumed by the dashboard.【F:routes/admin_reports.py†L16-L360】
+
+## Executive dashboard
+
+- Routes: `GET /admin` and `GET /admin/dashboard` render the executive dashboard with a rolling time window based on `range` query params (`30d`, `60d`, `90d`, `6m`, `1y`). The controller queries attendance, volunteer fulfilment, giving, assimilation, and recent care follow-ups via `ReportingService` utilities.【F:routes/admin.py†L54-L85】
+- Templates:
+  - `templates/admin/dashboard/index.html` composes the page shell, export shortcuts, and injects partials for the analytic cards plus the recent care follow-up list.【F:templates/admin/dashboard/index.html†L4-L69】
+  - `dashboard/filters.html` supplies the timeframe `<form>` so leaders can pivot the range inline.【F:templates/admin/dashboard/filters.html†L1-L18】
+  - `dashboard/attendance_panel.html`, `dashboard/volunteer_panel.html`, `dashboard/giving_panel.html`, and `dashboard/assimilation_panel.html` break out each analytic widget, rendering totals, subtables, and sparkline-style summaries from the JSON payload returned by `ReportingService`.【F:templates/admin/dashboard/attendance_panel.html†L1-L46】【F:templates/admin/dashboard/volunteer_panel.html†L1-L43】【F:templates/admin/dashboard/giving_panel.html†L1-L40】【F:templates/admin/dashboard/assimilation_panel.html†L1-L46】
+  - The dashboard also surfaces the five most recent care interactions pulled by `_recent_care_followups`, highlighting member names, interaction types, dates, and notes.【F:routes/admin.py†L66-L85】【F:templates/admin/dashboard/index.html†L36-L65】
+- Reporting API: `/admin/reports/metrics` hydrates the dashboard, while `/admin/reports/*.csv` endpoints provide downloadable exports for attendance, volunteers, giving, and assimilation funnels.【F:routes/admin_reports.py†L262-L358】
+
+## User management
+
+- Routes: `GET /admin/users` lists accounts, `GET/POST /admin/users/create` handles creation, `GET/POST /admin/users/<id>/edit` updates profiles and triggers automations when admin status flips, `/admin/users/<id>/delete` deletes accounts with a self-delete guard, and `/admin/users/import` is currently a stub that flashes a notice.【F:routes/admin.py†L88-L171】
+- Templates:
+  - `templates/admin/users.html` renders the data table, action buttons, flash messaging, and the CSV import modal scaffold.【F:templates/admin/users.html†L4-L117】
+  - `templates/admin/user_form.html` provides the create/edit form with validation hints, admin toggle, and contextual help copy.【F:templates/admin/user_form.html†L4-L119】
+  - `templates/admin/user_import.html` (legacy partial referenced by the modal) mirrors the bulk import expectations if the feature is revived.【F:templates/admin/user_import.html†L1-L39】
+
+## Member care & follow-up
+
+- Routes: `GET /admin/members` lists members (currently without search filtering in the controller) and `GET /admin/members/<id>` renders the profile with interaction history; `_recent_care_followups` supports dashboard rollups.【F:routes/admin.py†L79-L199】
+- Templates:
+  - `templates/admin/members/index.html` surfaces filters for search/status, assimilation progress bars, follow-up due badges, and deep links into member profiles.【F:templates/admin/members/index.html†L4-L96】
+  - `templates/admin/members/detail.html` shows profile stats, milestone checklist, household info, a rich follow-up logging form (interaction type, dates, milestone updates), and the interaction feed. The form references routes such as `admin.log_member_follow_up` that are not yet implemented server-side.【F:templates/admin/members/detail.html†L4-L180】
+
+## Prayer requests moderation
+
+- Route: `GET /admin/prayers` lists inbound requests with modal detail views and action buttons intended to toggle visibility or delete entries; the related POST routes are not present in the blueprint yet.【F:routes/admin.py†L173-L178】【F:templates/admin/prayers.html†L4-L84】
+
+## Additional admin templates awaiting endpoints
+
+- The `templates/admin/` tree also contains layouts for events, volunteer assignments, automations, donations, gallery, facilities, sermons, and settings management. These articulate desired CRUD flows—event creation/editing, volunteer assignment forms, facility reservation conflict warnings, content uploads, etc.—but corresponding Flask routes have not been wired up in `routes/admin.py`, indicating future work for the Prisma-backed services.【F:templates/admin/events.html†L4-L86】【F:templates/admin/event_form.html†L4-L118】【F:templates/admin/volunteers/index.html†L4-L68】【F:templates/admin/volunteers/form.html†L4-L79】【F:templates/admin/donations.html†L4-L68】【F:templates/admin/gallery.html†L4-L63】【F:templates/admin/facilities.html†L4-L200】【F:templates/admin/settings.html†L4-L196】
+
+## Observations & gaps
+
+- Several templates post to routes such as `admin.log_member_follow_up`, `admin.toggle_prayer_visibility`, `admin.delete_prayer`, and other CRUD handlers that are absent in `routes/admin.py`, reinforcing that the Next.js/Prisma migration must supply API endpoints for those interactions before the UI can be fully functional.【F:templates/admin/members/detail.html†L108-L166】【F:templates/admin/prayers.html†L38-L66】
+- The reporting service already structures data in a JSON-friendly shape, making it straightforward to mirror in the forthcoming Next.js admin dashboard and to expose via Prisma-powered REST endpoints.【F:routes/admin_reports.py†L31-L241】


### PR DESCRIPTION
## Summary
- document the current Flask-based admin dashboards and flows in docs/admin_inventory.md to guide the migration
- add a Prisma-aware admin API client plus the new /admin layout, dashboard panels, care hub, and user management UI with optimistic server actions
- wire Playwright end-to-end coverage, a reusable apiRequest helper, and enable server actions so the admin area can be tested headlessly

## Testing
- npm run lint -w apps/frontend
- npm run test:e2e -w apps/frontend

------
https://chatgpt.com/codex/tasks/task_e_68d16801cc7883339c9e60e5515c4ee9