### PR TITLE
Add containerization tooling and CI image publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,67 @@ jobs:
             apps/backend/coverage
             apps/frontend/coverage
           if-no-files-found: ignore
+
+  docker-images:
+    name: Build & Publish Images
+    needs: quality
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Authenticate to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Backend image metadata
+        id: meta_backend
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/backend
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha
+
+      - name: Build backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: apps/backend/Dockerfile
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta_backend.outputs.tags }}
+          labels: ${{ steps.meta_backend.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ github.sha }}
+
+      - name: Frontend image metadata
+        id: meta_frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/frontend
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha
+
+      - name: Build frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: apps/frontend/Dockerfile
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta_frontend.outputs.tags }}
+          labels: ${{ steps.meta_frontend.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ github.sha }}

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.6
+
+FROM node:20-bookworm-slim AS base
+WORKDIR /usr/src/app
+
+FROM base AS deps
+# Copy workspace manifests to leverage npm's workspaces resolver during install
+COPY package.json ./
+COPY apps/backend/package.json ./apps/backend/package.json
+COPY packages/shared/package.json ./packages/shared/package.json
+RUN npm install
+
+FROM deps AS build
+COPY . .
+RUN npm run build --workspace packages/shared \
+  && npm run build --workspace apps/backend
+
+FROM deps AS production-deps
+RUN npm prune --omit=dev \
+  && npm install prisma --no-save
+
+FROM node:20-bookworm-slim AS runner
+WORKDIR /usr/src/app
+ENV NODE_ENV=production
+ARG APP_VERSION=0.0.0
+ENV APP_VERSION=${APP_VERSION}
+LABEL org.opencontainers.image.title="Covenant Connect Backend"
+LABEL org.opencontainers.image.version="${APP_VERSION}"
+
+COPY --from=production-deps /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/package.json ./package.json
+COPY --from=build /usr/src/app/apps/backend/package.json ./apps/backend/package.json
+COPY --from=build /usr/src/app/apps/backend/dist ./apps/backend/dist
+COPY --from=build /usr/src/app/apps/backend/prisma ./apps/backend/prisma
+COPY --from=build /usr/src/app/packages/shared/package.json ./packages/shared/package.json
+COPY --from=build /usr/src/app/packages/shared/dist ./packages/shared/dist
+
+EXPOSE 8000
+CMD ["sh", "-c", "npx prisma migrate deploy && node apps/backend/dist/main.js"]

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.6
+
+FROM node:20-bookworm-slim AS base
+WORKDIR /usr/src/app
+
+FROM base AS deps
+COPY package.json ./
+COPY apps/frontend/package.json ./apps/frontend/package.json
+COPY packages/shared/package.json ./packages/shared/package.json
+RUN npm install
+
+FROM deps AS build
+COPY . .
+RUN npm run build --workspace packages/shared \
+  && npm run build --workspace apps/frontend
+
+FROM deps AS production-deps
+RUN npm prune --omit=dev
+
+FROM node:20-bookworm-slim AS runner
+WORKDIR /usr/src/app
+ENV NODE_ENV=production
+ENV PORT=3000
+ARG APP_VERSION=0.0.0
+ENV APP_VERSION=${APP_VERSION}
+ENV NEXT_TELEMETRY_DISABLED=1
+LABEL org.opencontainers.image.title="Covenant Connect Frontend"
+LABEL org.opencontainers.image.version="${APP_VERSION}"
+
+COPY --from=production-deps /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/package.json ./package.json
+COPY --from=build /usr/src/app/apps/frontend/package.json ./apps/frontend/package.json
+COPY --from=build /usr/src/app/apps/frontend/next.config.js ./apps/frontend/next.config.js
+COPY --from=build /usr/src/app/apps/frontend/public ./apps/frontend/public
+COPY --from=build /usr/src/app/apps/frontend/.next ./apps/frontend/.next
+COPY --from=build /usr/src/app/packages/shared/package.json ./packages/shared/package.json
+COPY --from=build /usr/src/app/packages/shared/dist ./packages/shared/dist
+
+EXPOSE 3000
+CMD ["sh", "-c", "node apps/frontend/node_modules/next/dist/bin/next start -p ${PORT:-3000}"]

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: covenant-connect
+description: Helm chart that provisions the Covenant Connect application stack (frontend, backend, Redis, and PostgreSQL)
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{- define "covenant-connect.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "covenant-connect.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "covenant-connect.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+app.kubernetes.io/name: {{ include "covenant-connect.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "covenant-connect.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "covenant-connect.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "covenant-connect.backendName" -}}
+{{ include "covenant-connect.fullname" . }}-backend
+{{- end -}}
+
+{{- define "covenant-connect.frontendName" -}}
+{{ include "covenant-connect.fullname" . }}-frontend
+{{- end -}}
+
+{{- define "covenant-connect.redisName" -}}
+{{ include "covenant-connect.fullname" . }}-redis
+{{- end -}}
+
+{{- define "covenant-connect.postgresName" -}}
+{{ include "covenant-connect.fullname" . }}-postgres
+{{- end -}}
+
+{{- define "covenant-connect.backendSecretName" -}}
+{{ include "covenant-connect.fullname" . }}-backend-env
+{{- end -}}
+
+{{- define "covenant-connect.postgresSecretName" -}}
+{{ include "covenant-connect.fullname" . }}-postgres
+{{- end -}}
+
+{{- define "covenant-connect.redisSecretName" -}}
+{{ include "covenant-connect.fullname" . }}-redis-auth
+{{- end -}}

--- a/deploy/helm/templates/backend-deployment.yaml
+++ b/deploy/helm/templates/backend-deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "covenant-connect.backendName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "covenant-connect.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "covenant-connect.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: {{ printf "%s:%s" .Values.backend.image.repository .Values.backend.image.tag | quote }}
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.backend.service.port }}
+              name: http
+          env:
+            - name: APP_VERSION
+              value: {{ default .Chart.AppVersion .Values.backend.env.APP_VERSION | quote }}
+            {{- range $key, $value := .Values.backend.env }}
+            {{- if ne $key "APP_VERSION" }}
+            - name: {{ $key }}
+              value: {{ tpl (printf "%v" $value) $ | quote }}
+            {{- end }}
+            {{- end }}
+            {{- range $key, $_ := .Values.backend.secretEnv }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "covenant-connect.backendSecretName" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}

--- a/deploy/helm/templates/backend-secret.yaml
+++ b/deploy/helm/templates/backend-secret.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.redis.auth.enabled (not .Values.redis.auth.password) -}}
+{{- fail "redis.auth.password must be set when redis.auth.enabled is true" -}}
+{{- end -}}
+{{- $backendSecret := include "covenant-connect.backendSecretName" . -}}
+{{- $postgresHost := printf "%s:%d" (include "covenant-connect.postgresName" .) (.Values.postgres.service.port | default 5432) -}}
+{{- $postgresUser := .Values.postgres.auth.username | default "postgres" -}}
+{{- $postgresPassword := .Values.postgres.auth.password | default "postgres" -}}
+{{- $postgresDatabase := .Values.postgres.auth.database | default "postgres" -}}
+{{- $defaultDatabaseUrl := printf "postgresql://%s:%s@%s/%s?schema=public" $postgresUser $postgresPassword $postgresHost $postgresDatabase -}}
+{{- $redisHost := printf "%s:%d" (include "covenant-connect.redisName" .) (.Values.redis.service.port | default 6379) -}}
+{{- $defaultRedisUrl := ternary (printf "redis://:%s@%s/0" .Values.redis.auth.password $redisHost) (printf "redis://%s/0" $redisHost) (.Values.redis.auth.enabled | default false) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $backendSecret }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  SESSION_SECRET: {{ default "change-me" .Values.backend.secretEnv.SESSION_SECRET | quote }}
+  DATABASE_URL: {{ default $defaultDatabaseUrl .Values.backend.secretEnv.DATABASE_URL | quote }}
+  SHADOW_DATABASE_URL: {{ default "" .Values.backend.secretEnv.SHADOW_DATABASE_URL | quote }}
+  REDIS_URL: {{ default $defaultRedisUrl .Values.backend.secretEnv.REDIS_URL | quote }}
+  STRIPE_SECRET_KEY: {{ default "" .Values.backend.secretEnv.STRIPE_SECRET_KEY | quote }}
+  STRIPE_WEBHOOK_SECRET: {{ default "" .Values.backend.secretEnv.STRIPE_WEBHOOK_SECRET | quote }}
+  PAYSTACK_SECRET_KEY: {{ default "" .Values.backend.secretEnv.PAYSTACK_SECRET_KEY | quote }}
+  PAYSTACK_WEBHOOK_SECRET: {{ default "" .Values.backend.secretEnv.PAYSTACK_WEBHOOK_SECRET | quote }}
+  FINCRA_SECRET_KEY: {{ default "" .Values.backend.secretEnv.FINCRA_SECRET_KEY | quote }}
+  FINCRA_WEBHOOK_SECRET: {{ default "" .Values.backend.secretEnv.FINCRA_WEBHOOK_SECRET | quote }}
+  FLUTTERWAVE_SECRET_KEY: {{ default "" .Values.backend.secretEnv.FLUTTERWAVE_SECRET_KEY | quote }}
+  FLUTTERWAVE_WEBHOOK_SECRET: {{ default "" .Values.backend.secretEnv.FLUTTERWAVE_WEBHOOK_SECRET | quote }}
+  GOOGLE_CLIENT_ID: {{ default "" .Values.backend.secretEnv.GOOGLE_CLIENT_ID | quote }}
+  GOOGLE_CLIENT_SECRET: {{ default "" .Values.backend.secretEnv.GOOGLE_CLIENT_SECRET | quote }}
+  FACEBOOK_CLIENT_ID: {{ default "" .Values.backend.secretEnv.FACEBOOK_CLIENT_ID | quote }}
+  FACEBOOK_CLIENT_SECRET: {{ default "" .Values.backend.secretEnv.FACEBOOK_CLIENT_SECRET | quote }}
+  APPLE_CLIENT_ID: {{ default "" .Values.backend.secretEnv.APPLE_CLIENT_ID | quote }}
+  APPLE_TEAM_ID: {{ default "" .Values.backend.secretEnv.APPLE_TEAM_ID | quote }}
+  APPLE_KEY_ID: {{ default "" .Values.backend.secretEnv.APPLE_KEY_ID | quote }}
+  APPLE_PRIVATE_KEY: {{ default "" .Values.backend.secretEnv.APPLE_PRIVATE_KEY | quote }}
+  AWS_S3_BUCKET: {{ default "" .Values.backend.secretEnv.AWS_S3_BUCKET | quote }}
+  AWS_REGION: {{ default "us-east-1" .Values.backend.secretEnv.AWS_REGION | quote }}
+  AWS_ACCESS_KEY_ID: {{ default "" .Values.backend.secretEnv.AWS_ACCESS_KEY_ID | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ default "" .Values.backend.secretEnv.AWS_SECRET_ACCESS_KEY | quote }}
+  ASSET_BASE_URL: {{ default "" .Values.backend.secretEnv.ASSET_BASE_URL | quote }}
+  SESSION_TTL: {{ default "604800" .Values.backend.secretEnv.SESSION_TTL | quote }}
+  COOKIE_SECURE: {{ default "true" .Values.backend.secretEnv.COOKIE_SECURE | quote }}
+  COOKIE_DOMAIN: {{ default "" .Values.backend.secretEnv.COOKIE_DOMAIN | quote }}
+  KPI_DIGEST_CRON: {{ default "0 7 * * 1" .Values.backend.secretEnv.KPI_DIGEST_CRON | quote }}
+  FOLLOW_UP_CRON: {{ default "0 */6 * * *" .Values.backend.secretEnv.FOLLOW_UP_CRON | quote }}

--- a/deploy/helm/templates/backend-service.yaml
+++ b/deploy/helm/templates/backend-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "covenant-connect.backendName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: {{ .Values.backend.service.type }}
+  selector:
+    {{- include "covenant-connect.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+  ports:
+    - name: http
+      port: {{ .Values.backend.service.port }}
+      targetPort: http

--- a/deploy/helm/templates/frontend-deployment.yaml
+++ b/deploy/helm/templates/frontend-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "covenant-connect.frontendName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "covenant-connect.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "covenant-connect.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: {{ printf "%s:%s" .Values.frontend.image.repository .Values.frontend.image.tag | quote }}
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.frontend.service.port }}
+              name: http
+          env:
+            - name: APP_VERSION
+              value: {{ default .Chart.AppVersion .Values.frontend.env.APP_VERSION | quote }}
+            {{- range $key, $value := .Values.frontend.env }}
+            {{- if ne $key "APP_VERSION" }}
+            - name: {{ $key }}
+              value: {{ tpl (printf "%v" $value) $ | quote }}
+            {{- end }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}

--- a/deploy/helm/templates/frontend-ingress.yaml
+++ b/deploy/helm/templates/frontend-ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "covenant-connect.frontendName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+  {{- if .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- $root := . -}}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "covenant-connect.frontendName" $root }}
+                port:
+                  number: {{ $root.Values.frontend.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/templates/frontend-service.yaml
+++ b/deploy/helm/templates/frontend-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "covenant-connect.frontendName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: {{ .Values.frontend.service.type }}
+  selector:
+    {{- include "covenant-connect.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+  ports:
+    - name: http
+      port: {{ .Values.frontend.service.port }}
+      targetPort: http

--- a/deploy/helm/templates/postgres-secret.yaml
+++ b/deploy/helm/templates/postgres-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "covenant-connect.postgresSecretName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+type: Opaque
+stringData:
+  POSTGRES_USER: {{ .Values.postgres.auth.username | quote }}
+  POSTGRES_PASSWORD: {{ .Values.postgres.auth.password | quote }}
+  POSTGRES_DB: {{ .Values.postgres.auth.database | quote }}

--- a/deploy/helm/templates/postgres-service.yaml
+++ b/deploy/helm/templates/postgres-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "covenant-connect.postgresName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "covenant-connect.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+  ports:
+    - name: postgres
+      port: {{ .Values.postgres.service.port }}
+      targetPort: postgres

--- a/deploy/helm/templates/postgres-statefulset.yaml
+++ b/deploy/helm/templates/postgres-statefulset.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "covenant-connect.postgresName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: {{ include "covenant-connect.postgresName" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "covenant-connect.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        {{- include "covenant-connect.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.postgres.service.port }}
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "covenant-connect.postgresSecretName" . }}
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "covenant-connect.postgresSecretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "covenant-connect.postgresSecretName" . }}
+                  key: POSTGRES_DB
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER"
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      {{- if not .Values.postgres.persistence.enabled }}
+      volumes:
+        - name: postgres-data
+          emptyDir: {}
+      {{- end }}
+  {{- if .Values.postgres.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          {{- toYaml .Values.postgres.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.persistence.size }}
+        {{- if .Values.postgres.persistence.storageClassName }}
+        storageClassName: {{ .Values.postgres.persistence.storageClassName }}
+        {{- end }}
+  {{- end }}

--- a/deploy/helm/templates/redis-secret.yaml
+++ b/deploy/helm/templates/redis-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.redis.auth.enabled .Values.redis.auth.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "covenant-connect.redisSecretName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+type: Opaque
+stringData:
+  REDIS_PASSWORD: {{ .Values.redis.auth.password | quote }}
+{{- end }}

--- a/deploy/helm/templates/redis-service.yaml
+++ b/deploy/helm/templates/redis-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "covenant-connect.redisName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "covenant-connect.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+  ports:
+    - name: redis
+      port: {{ .Values.redis.service.port }}
+      targetPort: redis

--- a/deploy/helm/templates/redis-statefulset.yaml
+++ b/deploy/helm/templates/redis-statefulset.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "covenant-connect.redisName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  serviceName: {{ include "covenant-connect.redisName" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "covenant-connect.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "covenant-connect.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              if [ -n "${REDIS_PASSWORD:-}" ]; then
+                exec redis-server --appendonly yes --requirepass "${REDIS_PASSWORD}"
+              else
+                exec redis-server --appendonly yes
+              fi
+          ports:
+            - containerPort: {{ .Values.redis.service.port }}
+              name: redis
+          {{- if and .Values.redis.auth.enabled .Values.redis.auth.password }}
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "covenant-connect.redisSecretName" . }}
+                  key: REDIS_PASSWORD
+          {{- end }}
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+      {{- if not .Values.redis.persistence.enabled }}
+      volumes:
+        - name: redis-data
+          emptyDir: {}
+      {{- end }}
+  {{- if .Values.redis.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes:
+          {{- toYaml .Values.redis.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.persistence.size }}
+        {{- if .Values.redis.persistence.storageClassName }}
+        storageClassName: {{ .Values.redis.persistence.storageClassName }}
+        {{- end }}
+  {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,105 @@
+global:
+  imagePullSecrets: []
+
+backend:
+  replicaCount: 2
+  image:
+    repository: ghcr.io/example/covenant-connect/backend
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 8000
+  resources: {}
+  env:
+    APP_NAME: Covenant Connect
+    NODE_ENV: production
+    PORT: "8000"
+    QUEUE_DRIVER: redis
+    CORS_ORIGINS: https://app.example.com,https://admin.example.com
+  secretEnv:
+    SESSION_SECRET: "change-me"
+    DATABASE_URL: ""
+    SHADOW_DATABASE_URL: ""
+    REDIS_URL: ""
+    STRIPE_SECRET_KEY: ""
+    STRIPE_WEBHOOK_SECRET: ""
+    PAYSTACK_SECRET_KEY: ""
+    PAYSTACK_WEBHOOK_SECRET: ""
+    FINCRA_SECRET_KEY: ""
+    FINCRA_WEBHOOK_SECRET: ""
+    FLUTTERWAVE_SECRET_KEY: ""
+    FLUTTERWAVE_WEBHOOK_SECRET: ""
+    GOOGLE_CLIENT_ID: ""
+    GOOGLE_CLIENT_SECRET: ""
+    FACEBOOK_CLIENT_ID: ""
+    FACEBOOK_CLIENT_SECRET: ""
+    APPLE_CLIENT_ID: ""
+    APPLE_TEAM_ID: ""
+    APPLE_KEY_ID: ""
+    APPLE_PRIVATE_KEY: ""
+    AWS_S3_BUCKET: ""
+    AWS_REGION: us-east-1
+    AWS_ACCESS_KEY_ID: ""
+    AWS_SECRET_ACCESS_KEY: ""
+    ASSET_BASE_URL: ""
+    SESSION_TTL: "604800"
+    COOKIE_SECURE: "true"
+    COOKIE_DOMAIN: app.example.com
+    KPI_DIGEST_CRON: "0 7 * * 1"
+    FOLLOW_UP_CRON: "0 */6 * * *"
+
+frontend:
+  replicaCount: 2
+  image:
+    repository: ghcr.io/example/covenant-connect/frontend
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 3000
+  resources: {}
+  env:
+    NODE_ENV: production
+    PORT: "3000"
+    NEXT_PUBLIC_API_BASE_URL: http://{{ include "covenant-connect.fullname" . }}-backend:8000
+
+redis:
+  image: redis:7.2-alpine
+  service:
+    port: 6379
+  persistence:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    storageClassName: ""
+  auth:
+    enabled: false
+    password: ""
+
+postgres:
+  image: postgres:15-alpine
+  service:
+    port: 5432
+  auth:
+    username: covenant_connect
+    password: change-me
+    database: covenant_connect
+  persistence:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    storageClassName: ""
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: frontend.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,76 @@
+version: '3.9'
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: apps/backend/Dockerfile
+      args:
+        APP_VERSION: local
+    image: covenant-connect/backend:local
+    environment:
+      APP_NAME: Covenant Connect
+      APP_VERSION: local
+      NODE_ENV: production
+      PORT: 8000
+      DATABASE_URL: postgresql://covenant_connect:covenantconnect@db:5432/covenant_connect?schema=public
+      REDIS_URL: redis://redis:6379/0
+      SESSION_SECRET: localdevsupersecret
+      CORS_ORIGINS: http://localhost:3000
+      QUEUE_DRIVER: redis
+      STORAGE_DRIVER: local
+      LOCAL_STORAGE_DIR: /tmp/uploads
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - '8000:8000'
+
+  frontend:
+    build:
+      context: .
+      dockerfile: apps/frontend/Dockerfile
+      args:
+        APP_VERSION: local
+    image: covenant-connect/frontend:local
+    environment:
+      APP_VERSION: local
+      NODE_ENV: production
+      PORT: 3000
+      NEXT_PUBLIC_API_BASE_URL: http://backend:8000
+    depends_on:
+      backend:
+        condition: service_started
+    ports:
+      - '3000:3000'
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: covenant_connect
+      POSTGRES_USER: covenant_connect
+      POSTGRES_PASSWORD: covenantconnect
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7.2-alpine
+    command: ['redis-server', '--save', '', '--appendonly', 'no']
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres-data:
+  redis-data:


### PR DESCRIPTION
## Summary
- add production-ready Dockerfiles for the Nest API and Next.js frontend along with a local docker-compose stack
- introduce a Helm chart that deploys the backend, frontend, PostgreSQL, Redis, and related secrets
- document deployment variables and steps while extending CI to build and publish images to GHCR

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d18fb5f3a88333b74c45bea5f2f3b5