### PR TITLE
feat: expose Prisma types from shared package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ apps/**/dist/
 apps/**/.turbo/
 apps/**/coverage/
 packages/**/dist/
+packages/**/src/generated/
 pnpm-lock.yaml
 package-lock.json
 yarn.lock

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,6 +7,7 @@
     "seed": "ts-node --transpile-only prisma/seed.ts"
   },
   "scripts": {
+    "prisma:generate": "prisma generate",
     "build": "tsc -p tsconfig.build.json",
     "dev": "ts-node-dev --respawn --transpile-only src/main.ts",
     "start": "node dist/main.js",

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -3,6 +3,11 @@ generator client {
   provider = "prisma-client-js"
 }
 
+generator sharedTypes {
+  provider = "prisma-client-js"
+  output   = "../../../packages/shared/src/generated/prisma"
+}
+
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
     "packages/shared"
   ],
   "scripts": {
+    "prebuild": "pnpm run prisma:generate",
     "build": "npm run build --workspaces",
     "dev": "npm run dev -w apps/backend",
     "lint": "npm run lint --workspaces",
     "typecheck": "npm run typecheck --workspaces",
-    "test": "npm run test --workspaces"
+    "test": "npm run test --workspaces",
+    "prisma:generate": "pnpm --filter @covenant-connect/backend prisma:generate",
+    "postinstall": "pnpm run prisma:generate"
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,49 +1,33 @@
+export type {
+  Prisma,
+  PrismaClient,
+  User,
+  Member,
+  AccountProvider,
+  Donation,
+  Event,
+  PrayerRequest,
+  Automation,
+  AutomationStep,
+  VolunteerAssignment,
+  IntegrationSetting,
+  Church,
+  Sermon,
+} from './generated/prisma';
+
+import type {
+  AccountProvider,
+  User,
+  Member,
+  EmailProvider as PrismaEmailProvider,
+} from './generated/prisma';
+
 export type Provider = 'google' | 'facebook' | 'apple' | 'password';
 
-export type UserAccount = {
-  id: string;
-  email: string;
-  passwordHash?: string;
-  firstName: string;
-  lastName: string;
-  avatarUrl?: string;
-  createdAt: Date;
-  updatedAt: Date;
-  roles: string[];
-  providers: ProviderIdentity[];
-};
-
-export type ProviderIdentity = {
-  provider: Provider;
-  providerId: string;
-  accessToken?: string;
-  refreshToken?: string;
-  expiresAt?: Date | null;
-};
-
-export type MemberProfile = {
-  id: string;
-  userId: string;
-  phone?: string;
-  address?: string;
-  dateOfBirth?: string;
-  gender?: 'male' | 'female' | 'unspecified';
-  nextSteps: string[];
-  createdAt: Date;
-  updatedAt: Date;
-};
-
-export type Donation = {
-  id: string;
-  memberId: string | null;
-  amount: number;
-  currency: string;
-  provider: 'paystack' | 'fincra' | 'stripe' | 'flutterwave';
-  status: 'pending' | 'completed' | 'failed' | 'refunded';
-  metadata: Record<string, unknown>;
-  createdAt: Date;
-  updatedAt: Date;
-};
+export type ProviderIdentity = AccountProvider;
+export type UserAccount = User;
+export type MemberProfile = Member;
+export type EmailProvider = PrismaEmailProvider;
 
 export type EventSegment = {
   id: string;
@@ -53,74 +37,12 @@ export type EventSegment = {
   ownerId: string | null;
 };
 
-export type Event = {
-  id: string;
-  title: string;
-  description?: string;
-  startsAt: Date;
-  endsAt: Date;
-  timezone: string;
-  recurrenceRule?: string;
-  segments: EventSegment[];
-  tags: string[];
-  location: string;
-  createdAt: Date;
-  updatedAt: Date;
-};
-
-export type PrayerRequest = {
-  id: string;
-  requesterName: string;
-  requesterEmail?: string;
-  requesterPhone?: string;
-  message: string;
-  memberId?: string;
-  status: 'new' | 'assigned' | 'praying' | 'answered';
-  followUpAt?: Date;
-  createdAt: Date;
-  updatedAt: Date;
-};
-
-export type Automation = {
-  id: string;
-  name: string;
-  trigger: string;
-  isActive: boolean;
-  steps: AutomationStep[];
-};
-
-export type AutomationStep = {
-  id: string;
-  type: 'email' | 'sms' | 'task' | 'webhook';
-  configuration: Record<string, unknown>;
-  delaySeconds: number;
-};
-
 export type EmailProviderType = 'ses' | 'mailgun' | 'smtp';
-
-export type EmailProvider = {
-  id: string;
-  type: EmailProviderType;
-  name: string;
-  credentials: Record<string, string>;
-  isActive: boolean;
-  createdAt: Date;
-  updatedAt: Date;
-};
 
 export type DashboardKpi = {
   label: string;
   value: number;
   change?: number;
-};
-
-export type Sermon = {
-  id: string;
-  title: string;
-  speaker: string;
-  description?: string;
-  mediaUrl?: string;
-  recordedAt?: Date;
 };
 
 export type HomeContent = {
@@ -130,36 +52,8 @@ export type HomeContent = {
   nextSteps: { label: string; url: string }[];
 };
 
-export type VolunteerAssignment = {
-  id: string;
-  eventId: string;
-  memberId: string;
-  role: string;
-  status: 'confirmed' | 'pending' | 'declined';
-};
-
-export type IntegrationSetting = {
-  id: number;
-  provider: string;
-  config: Record<string, string>;
-  createdAt: Date;
-  updatedAt: Date;
-};
-
-export type Church = {
-  id: string;
-  name: string;
-  timezone: string;
-  country?: string;
-  state?: string;
-  city?: string;
-  settings: Record<string, unknown>;
-  createdAt: Date;
-  updatedAt: Date;
-};
-
 export type NotificationPreference = {
-  memberId: string;
+  memberId: Member['id'];
   email: boolean;
   sms: boolean;
   push: boolean;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'


### PR DESCRIPTION
## Summary
- configure the Prisma schema to emit a shared client for the shared package
- replace manual shared typings with re-exports from the generated Prisma output and keep custom helpers
- wire pnpm scripts/workspace config so install/build regenerate the shared Prisma types and ignore generated artifacts

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68d1b9e792b08333af42427a70fa18ac