### PR TITLE
Specify pnpm version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,23 +12,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+          run_install: false
+
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: npm install
+        run: pnpm install
 
       - name: Lint
-        run: npm run lint
+        run: pnpm lint
 
       - name: Type check
-        run: npm run typecheck
+        run: pnpm typecheck
 
       - name: Run tests
-        run: npm run test
+        run: pnpm test
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- specify pnpm version when setting up pnpm in the CI workflow to satisfy the action requirements

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d1d0b1af4883339fa1d4761fed2c49