### PR TITLE
feat: persist church profiles via Prisma

### DIFF
--- a/apps/backend/prisma/migrations/20251102143000_extend_church_profile/migration.sql
+++ b/apps/backend/prisma/migrations/20251102143000_extend_church_profile/migration.sql
@@ -1,0 +1,18 @@
+-- AlterTable
+ALTER TABLE "public"."churches"
+ADD COLUMN     "timezone" TEXT,
+ADD COLUMN     "country" TEXT,
+ADD COLUMN     "state" TEXT,
+ADD COLUMN     "city" TEXT,
+ADD COLUMN     "settings" JSONB DEFAULT '{}'::jsonb,
+ADD COLUMN     "updated_at" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE "public"."churches"
+SET "timezone" = COALESCE("timezone", 'UTC'),
+    "settings" = COALESCE("settings", '{}'::jsonb),
+    "updated_at" = COALESCE("updated_at", CURRENT_TIMESTAMP);
+
+ALTER TABLE "public"."churches"
+ALTER COLUMN "timezone" SET NOT NULL,
+ALTER COLUMN "settings" SET NOT NULL,
+ALTER COLUMN "updated_at" SET NOT NULL;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -252,7 +252,13 @@ model Church {
   id        Int      @id @default(autoincrement())
   name      String
   address   String?
+  timezone  String   @default("UTC")
+  country   String?
+  state     String?
+  city      String?
+  settings  Json     @default("{}")
   createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
   @@map("churches")
 }

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -19,7 +19,11 @@ async function main(): Promise<void> {
     create: {
       id: 1,
       name: 'Covenant Connect Church',
-      address: '123 Covenant Way'
+      address: '123 Covenant Way',
+      timezone: 'America/New_York',
+      country: 'USA',
+      state: 'NY',
+      city: 'New York'
     }
   });
 }

--- a/apps/backend/src/modules/churches/churches.controller.ts
+++ b/apps/backend/src/modules/churches/churches.controller.ts
@@ -3,12 +3,23 @@ import type { Church } from '@covenant-connect/shared';
 
 import { ChurchesService } from './churches.service';
 
+type CreateChurchRequest = {
+  name: string;
+  timezone: string;
+  country?: string | null;
+  state?: string | null;
+  city?: string | null;
+  settings?: Record<string, unknown>;
+};
+
+type UpdateChurchRequest = Partial<CreateChurchRequest>;
+
 @Controller('churches')
 export class ChurchesController {
   constructor(private readonly churches: ChurchesService) {}
 
   @Post()
-  create(@Body() body: { name: string; timezone: string; country?: string; state?: string; city?: string }): Promise<Church> {
+  create(@Body() body: CreateChurchRequest): Promise<Church> {
     return this.churches.create(body);
   }
 
@@ -23,7 +34,7 @@ export class ChurchesController {
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() body: Partial<Church>): Promise<Church> {
+  update(@Param('id') id: string, @Body() body: UpdateChurchRequest): Promise<Church> {
     return this.churches.update(id, body);
   }
 }

--- a/apps/backend/src/modules/churches/churches.service.ts
+++ b/apps/backend/src/modules/churches/churches.service.ts
@@ -1,13 +1,16 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { randomUUID } from 'node:crypto';
 import type { Church } from '@covenant-connect/shared';
+import { Prisma } from '@prisma/client';
+import type { Church as ChurchModel } from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
 
 type CreateChurchInput = {
   name: string;
   timezone: string;
-  country?: string;
-  state?: string;
-  city?: string;
+  country?: string | null;
+  state?: string | null;
+  city?: string | null;
   settings?: Record<string, unknown>;
 };
 
@@ -15,50 +18,123 @@ type UpdateChurchInput = Partial<CreateChurchInput>;
 
 @Injectable()
 export class ChurchesService {
-  private readonly churches = new Map<string, Church>();
+  constructor(private readonly prisma: PrismaService) {}
 
   async create(input: CreateChurchInput): Promise<Church> {
-    const now = new Date();
-    const church: Church = {
-      id: randomUUID(),
-      name: input.name,
-      timezone: input.timezone,
-      country: input.country,
-      state: input.state,
-      city: input.city,
-      settings: input.settings ?? {},
-      createdAt: now,
-      updatedAt: now
-    };
+    const created = await this.prisma.church.create({
+      data: {
+        name: input.name,
+        timezone: input.timezone,
+        country: input.country ?? null,
+        state: input.state ?? null,
+        city: input.city ?? null,
+        settings: (input.settings ?? {}) as Prisma.InputJsonValue
+      }
+    });
 
-    this.churches.set(church.id, church);
-    return church;
+    return this.toDomain(created);
   }
 
   async list(): Promise<Church[]> {
-    return Array.from(this.churches.values());
+    const churches = await this.prisma.church.findMany({
+      orderBy: { createdAt: 'asc' }
+    });
+
+    return churches.map((church) => this.toDomain(church));
   }
 
   async getById(churchId: string): Promise<Church> {
-    const church = this.churches.get(churchId);
+    const id = this.parseId(churchId);
+    if (id === null) {
+      throw new NotFoundException('Church not found');
+    }
+
+    const church = await this.prisma.church.findUnique({ where: { id } });
     if (!church) {
       throw new NotFoundException('Church not found');
     }
 
-    return church;
+    return this.toDomain(church);
   }
 
   async update(churchId: string, input: UpdateChurchInput): Promise<Church> {
-    const existing = await this.getById(churchId);
+    const id = this.parseId(churchId);
+    if (id === null) {
+      throw new NotFoundException('Church not found');
+    }
 
-    const updated: Church = {
-      ...existing,
-      ...input,
-      settings: { ...existing.settings, ...(input.settings ?? {}) },
-      updatedAt: new Date()
+    const existing = await this.prisma.church.findUnique({ where: { id } });
+    if (!existing) {
+      throw new NotFoundException('Church not found');
+    }
+
+    const data: Prisma.ChurchUpdateInput = {};
+
+    if (input.name !== undefined) {
+      data.name = input.name;
+    }
+
+    if (input.timezone !== undefined) {
+      data.timezone = input.timezone;
+    }
+
+    if (input.country !== undefined) {
+      data.country = input.country ?? null;
+    }
+
+    if (input.state !== undefined) {
+      data.state = input.state ?? null;
+    }
+
+    if (input.city !== undefined) {
+      data.city = input.city ?? null;
+    }
+
+    if (input.settings !== undefined) {
+      const mergedSettings = {
+        ...this.normalizeSettings(existing.settings),
+        ...input.settings
+      };
+
+      data.settings = mergedSettings as Prisma.InputJsonValue;
+    }
+
+    const updated = await this.prisma.church.update({
+      where: { id },
+      data
+    });
+
+    return this.toDomain(updated);
+  }
+
+  private toDomain(church: ChurchModel): Church {
+    return {
+      id: church.id.toString(),
+      name: church.name,
+      timezone: church.timezone,
+      country: church.country ?? undefined,
+      state: church.state ?? undefined,
+      city: church.city ?? undefined,
+      settings: this.normalizeSettings(church.settings),
+      createdAt: church.createdAt,
+      updatedAt: church.updatedAt
     };
+  }
 
-    this.churches.set(updated.id, updated);
-    return updated;
+  private normalizeSettings(settings: Prisma.JsonValue | null | undefined): Record<string, unknown> {
+    if (!settings || Array.isArray(settings) || typeof settings !== 'object') {
+      return {};
+    }
+
+    return settings as Record<string, unknown>;
+  }
+
+  private parseId(id: string): number | null {
+    const parsed = Number.parseInt(id, 10);
+    if (Number.isNaN(parsed)) {
+      return null;
+    }
+
+    return parsed;
   }
 }

--- a/docs/js-architecture.md
+++ b/docs/js-architecture.md
@@ -49,7 +49,7 @@ apps/backend
 │       └── tasks/          # Background job queue abstraction
 ```
 
-Each module exposes a Nest `Module`, `Service`, and (where relevant) `Controller`. Today the services rely on in-memory stores to keep the initial commit lightweight; the method contracts align with Prisma models so the repository layer can swap to a real database with minimal churn.
+Each module exposes a Nest `Module`, `Service`, and (where relevant) `Controller`. Many services already persist data through Prisma (for example the accounts and churches modules), while the remaining modules still use in-memory stores whose method contracts align with the Prisma models for a straightforward swap to the database.
 
 ### Frontend structure
 


### PR DESCRIPTION
## Summary
- replace the churches service with a Prisma-backed implementation and tighten the controller contracts
- extend the Prisma schema and add a migration so church records store timezone, location, and settings metadata
- seed default church profile details and update the architecture doc to reflect the move toward database-backed modules

## Testing
- pnpm --filter @covenant-connect/backend prisma:generate
- pnpm --filter @covenant-connect/backend lint
- pnpm --filter @covenant-connect/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d1d39c0d6483339c41f058f0b7cd80