### PR TITLE
feat(frontend): add wordpress plugin marketing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ deployment.
 > landing experience and an operational dashboard. Shared domain interfaces are
 > published from [`packages/shared`](packages/shared), and the architecture is
 > documented in [docs/js-architecture.md](docs/js-architecture.md).
+>
+> Need to surface content on a church website? Drop the installable WordPress
+> plugin in [`integrations/wordpress-plugin`](integrations/wordpress-plugin)
+> into `wp-content/plugins`, configure the API endpoint, and use the provided
+> shortcodes to render sermons and events without custom theme work.
+> The Next.js frontend now ships a `/solutions/wordpress-plugin` landing page,
+> moving the marketing flow off the legacy Flask templates as we transition to
+> the all-TypeScript stack.
 
 ## Environment configuration
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,7 +21,7 @@
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.3.3",
     "@nestjs/platform-express": "^10.3.3",
-    "@nestjs/swagger": "^7.3.1",
+    "@nestjs/swagger": "^7.4.2",
     "@nestjs/terminus": "^10.2.1",
     "@aws-sdk/client-ses": "^3.679.0",
     "@prisma/client": "^6.16.2",
@@ -41,7 +41,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "stripe": "^14.0.0",
-    "swagger-ui-express": "^5.0.0"
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@nestjs/testing": "^10.3.3",

--- a/apps/backend/prisma/migrations/20251102143000_extend_church_profile/migration.sql
+++ b/apps/backend/prisma/migrations/20251102143000_extend_church_profile/migration.sql
@@ -1,0 +1,18 @@
+-- AlterTable
+ALTER TABLE "public"."churches"
+ADD COLUMN     "timezone" TEXT,
+ADD COLUMN     "country" TEXT,
+ADD COLUMN     "state" TEXT,
+ADD COLUMN     "city" TEXT,
+ADD COLUMN     "settings" JSONB DEFAULT '{}'::jsonb,
+ADD COLUMN     "updated_at" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE "public"."churches"
+SET "timezone" = COALESCE("timezone", 'UTC'),
+    "settings" = COALESCE("settings", '{}'::jsonb),
+    "updated_at" = COALESCE("updated_at", CURRENT_TIMESTAMP);
+
+ALTER TABLE "public"."churches"
+ALTER COLUMN "timezone" SET NOT NULL,
+ALTER COLUMN "settings" SET NOT NULL,
+ALTER COLUMN "updated_at" SET NOT NULL;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -252,7 +252,13 @@ model Church {
   id        Int      @id @default(autoincrement())
   name      String
   address   String?
+  timezone  String   @default("UTC")
+  country   String?
+  state     String?
+  city      String?
+  settings  Json     @default("{}")
   createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
   @@map("churches")
 }

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -19,7 +19,25 @@ async function main(): Promise<void> {
     create: {
       id: 1,
       name: 'Covenant Connect Church',
-      address: '123 Covenant Way'
+      address: '123 Covenant Way',
+      timezone: 'America/New_York',
+      country: 'USA',
+      state: 'NY',
+      city: 'New York'
+    }
+  });
+
+  await prisma.sermon.upsert({
+    where: { id: 1 },
+    update: {},
+    create: {
+      id: 1,
+      title: 'Welcome Home Sunday',
+      preacher: 'Pastor Alicia Turner',
+      description: 'Kick off the new season with a message of belonging and mission.',
+      date: new Date('2024-01-07T15:00:00Z'),
+      mediaUrl: 'https://media.covenantconnect.example/sermons/welcome-home',
+      mediaType: 'video'
     }
   });
 }

--- a/apps/backend/src/modules/churches/churches.controller.ts
+++ b/apps/backend/src/modules/churches/churches.controller.ts
@@ -3,12 +3,23 @@ import type { Church } from '@covenant-connect/shared';
 
 import { ChurchesService } from './churches.service';
 
+type CreateChurchRequest = {
+  name: string;
+  timezone: string;
+  country?: string | null;
+  state?: string | null;
+  city?: string | null;
+  settings?: Record<string, unknown> | null;
+};
+
+type UpdateChurchRequest = Partial<CreateChurchRequest>;
+
 @Controller('churches')
 export class ChurchesController {
   constructor(private readonly churches: ChurchesService) {}
 
   @Post()
-  create(@Body() body: { name: string; timezone: string; country?: string; state?: string; city?: string }): Promise<Church> {
+  create(@Body() body: CreateChurchRequest): Promise<Church> {
     return this.churches.create(body);
   }
 
@@ -23,7 +34,7 @@ export class ChurchesController {
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() body: Partial<Church>): Promise<Church> {
+  update(@Param('id') id: string, @Body() body: UpdateChurchRequest): Promise<Church> {
     return this.churches.update(id, body);
   }
 }

--- a/apps/backend/src/modules/churches/churches.service.spec.ts
+++ b/apps/backend/src/modules/churches/churches.service.spec.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { NotFoundException } from '@nestjs/common';
+import type { Church as PrismaChurch } from '@prisma/client';
+
+import { ChurchesService } from './churches.service';
+import type { PrismaService } from '../../prisma/prisma.service';
+
+type ChurchRecord = {
+  id: number;
+  name: string;
+  address: string | null;
+  timezone: string;
+  country: string | null;
+  state: string | null;
+  city: string | null;
+  settings: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+class InMemoryPrismaService {
+  private sequence = 1;
+  private readonly churches: ChurchRecord[] = [];
+  private timestamp = 1_000;
+
+  public readonly church = {
+    create: jest.fn(async ({ data }: { data: Record<string, unknown> }) => this.createChurch(data)),
+    findMany: jest.fn(async ({ orderBy }: { orderBy?: { createdAt?: 'asc' | 'desc' } } = {}) =>
+      this.findManyChurches(orderBy)
+    ),
+    findUnique: jest.fn(async ({ where }: { where: { id: number | string } }) =>
+      this.findUniqueChurch(where.id)
+    ),
+    update: jest.fn(async ({
+      where,
+      data,
+    }: {
+      where: { id: number | string };
+      data: Record<string, unknown>;
+    }) => this.updateChurch(where.id, data)),
+  };
+
+  private async createChurch(data: Record<string, unknown>): Promise<PrismaChurch> {
+    const now = this.nextTimestamp();
+
+    const record: ChurchRecord = {
+      id: this.sequence++,
+      name: (data.name as string) ?? 'Unnamed Church',
+      address: (data.address as string | null | undefined) ?? null,
+      timezone: (data.timezone as string) ?? 'UTC',
+      country: (data.country as string | null | undefined) ?? null,
+      state: (data.state as string | null | undefined) ?? null,
+      city: (data.city as string | null | undefined) ?? null,
+      settings: this.cloneSettings(data.settings),
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.churches.push(record);
+    return this.toModel(this.cloneRecord(record));
+  }
+
+  private async findManyChurches(orderBy?: { createdAt?: 'asc' | 'desc' }): Promise<PrismaChurch[]> {
+    const sorted = [...this.churches];
+
+    if (orderBy?.createdAt === 'asc') {
+      sorted.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    } else if (orderBy?.createdAt === 'desc') {
+      sorted.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    }
+
+    return sorted.map((record) => this.toModel(this.cloneRecord(record)));
+  }
+
+  private async findUniqueChurch(id: number | string): Promise<PrismaChurch | null> {
+    const numericId = typeof id === 'number' ? id : Number.parseInt(id, 10);
+    if (!Number.isInteger(numericId)) {
+      return null;
+    }
+
+    const record = this.churches.find((entry) => entry.id === numericId);
+    return record ? this.toModel(this.cloneRecord(record)) : null;
+  }
+
+  private async updateChurch(id: number | string, data: Record<string, unknown>): Promise<PrismaChurch> {
+    const numericId = typeof id === 'number' ? id : Number.parseInt(id, 10);
+    const record = this.churches.find((entry) => entry.id === numericId);
+
+    if (!record) {
+      throw new Error('Church not found');
+    }
+
+    if (data.name !== undefined) {
+      record.name = data.name as string;
+    }
+    if (data.timezone !== undefined) {
+      record.timezone = data.timezone as string;
+    }
+    if (data.country !== undefined) {
+      record.country = (data.country as string | null | undefined) ?? null;
+    }
+    if (data.state !== undefined) {
+      record.state = (data.state as string | null | undefined) ?? null;
+    }
+    if (data.city !== undefined) {
+      record.city = (data.city as string | null | undefined) ?? null;
+    }
+    if (data.settings !== undefined) {
+      record.settings = this.cloneSettings(data.settings);
+    }
+
+    record.updatedAt = this.nextTimestamp();
+    return this.toModel(this.cloneRecord(record));
+  }
+
+  private cloneRecord(record: ChurchRecord): ChurchRecord {
+    return {
+      ...record,
+      settings: { ...record.settings },
+      createdAt: new Date(record.createdAt.getTime()),
+      updatedAt: new Date(record.updatedAt.getTime()),
+    };
+  }
+
+  private cloneSettings(value: unknown): Record<string, unknown> {
+    if (
+      typeof value !== 'object' ||
+      value === null ||
+      Array.isArray(value) ||
+      Object.prototype.toString.call(value) !== '[object Object]'
+    ) {
+      return {};
+    }
+
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>));
+  }
+
+  private nextTimestamp(): Date {
+    return new Date(this.timestamp++);
+  }
+
+  private toModel(record: ChurchRecord): PrismaChurch {
+    return {
+      id: record.id,
+      name: record.name,
+      address: record.address,
+      timezone: record.timezone,
+      country: record.country,
+      state: record.state,
+      city: record.city,
+      settings: record.settings,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    } as PrismaChurch;
+  }
+}
+
+describe('ChurchesService', () => {
+  let prisma: InMemoryPrismaService;
+  let service: ChurchesService;
+
+  beforeEach(() => {
+    prisma = new InMemoryPrismaService();
+    service = new ChurchesService(prisma as unknown as PrismaService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a church and normalizes optional values', async () => {
+    const church = await service.create({
+      name: 'Grace Chapel',
+      timezone: 'America/New_York',
+      country: ' US ',
+      state: '',
+      city: '  ',
+      settings: { theme: 'light' },
+    });
+
+    expect(church).toMatchObject({
+      id: '1',
+      name: 'Grace Chapel',
+      timezone: 'America/New_York',
+      country: 'US',
+      state: undefined,
+      city: undefined,
+      settings: { theme: 'light' },
+    });
+  });
+
+  it('coerces non-object settings into an empty record on create', async () => {
+    const church = await service.create({
+      name: 'Community Church',
+      timezone: 'UTC',
+      settings: [] as unknown as Record<string, unknown>,
+    });
+
+    expect(church.settings).toEqual({});
+  });
+
+  it('lists churches ordered by creation time', async () => {
+    const first = await service.create({ name: 'First Church', timezone: 'UTC' });
+    const second = await service.create({ name: 'Second Church', timezone: 'UTC' });
+
+    const churches = await service.list();
+
+    expect(churches.map((entry) => entry.id)).toEqual([first.id, second.id]);
+  });
+
+  it('throws when requesting a church with a non-numeric identifier', async () => {
+    await service.create({ name: 'First Church', timezone: 'UTC' });
+
+    await expect(service.getById('abc')).rejects.toThrow(NotFoundException);
+    await expect(service.getById('1abc')).rejects.toThrow(NotFoundException);
+  });
+
+  it('updates a church and merges settings', async () => {
+    const created = await service.create({
+      name: 'Hope Church',
+      timezone: 'UTC',
+      country: 'US',
+      settings: { theme: 'light', donations: true },
+    });
+
+    const updated = await service.update(created.id, {
+      timezone: 'Africa/Lagos',
+      country: '  ',
+      settings: { theme: 'dark', announcements: true },
+    });
+
+    expect(updated).toMatchObject({
+      timezone: 'Africa/Lagos',
+      country: undefined,
+      settings: {
+        theme: 'dark',
+        donations: true,
+        announcements: true,
+      },
+    });
+  });
+
+  it('returns the existing church when no updates are provided', async () => {
+    const created = await service.create({ name: 'Stillwater Church', timezone: 'UTC' });
+
+    prisma.church.update.mockClear();
+
+    const result = await service.update(created.id, {});
+
+    expect(result).toEqual(created);
+    expect(prisma.church.update).not.toHaveBeenCalled();
+  });
+
+  it('ignores settings updates that cannot be merged', async () => {
+    const created = await service.create({
+      name: 'River Church',
+      timezone: 'UTC',
+      settings: { theme: 'light' },
+    });
+
+    prisma.church.update.mockClear();
+
+    const result = await service.update(created.id, { settings: null });
+
+    expect(result).toEqual(created);
+    expect(prisma.church.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when attempting to update a missing church', async () => {
+    await expect(service.update('999', { name: 'Missing Church' })).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/backend/src/modules/churches/churches.service.ts
+++ b/apps/backend/src/modules/churches/churches.service.ts
@@ -1,64 +1,207 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { randomUUID } from 'node:crypto';
 import type { Church } from '@covenant-connect/shared';
+import { Prisma } from '@prisma/client';
+import type { Church as ChurchModel } from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
 
 type CreateChurchInput = {
   name: string;
   timezone: string;
-  country?: string;
-  state?: string;
-  city?: string;
-  settings?: Record<string, unknown>;
+  country?: string | null;
+  state?: string | null;
+  city?: string | null;
+  settings?: Record<string, unknown> | null;
 };
 
 type UpdateChurchInput = Partial<CreateChurchInput>;
 
 @Injectable()
 export class ChurchesService {
-  private readonly churches = new Map<string, Church>();
+  constructor(private readonly prisma: PrismaService) {}
 
   async create(input: CreateChurchInput): Promise<Church> {
-    const now = new Date();
-    const church: Church = {
-      id: randomUUID(),
-      name: input.name,
-      timezone: input.timezone,
-      country: input.country,
-      state: input.state,
-      city: input.city,
-      settings: input.settings ?? {},
-      createdAt: now,
-      updatedAt: now
-    };
+    const created = await this.prisma.church.create({
+      data: {
+        name: input.name,
+        timezone: input.timezone,
+        country: this.toNullableString(input.country),
+        state: this.toNullableString(input.state),
+        city: this.toNullableString(input.city),
+        settings: this.prepareSettings(input.settings) as Prisma.InputJsonValue
+      }
+    });
 
-    this.churches.set(church.id, church);
-    return church;
+    return this.toDomain(created);
   }
 
   async list(): Promise<Church[]> {
-    return Array.from(this.churches.values());
+    const churches = await this.prisma.church.findMany({
+      orderBy: { createdAt: 'asc' }
+    });
+
+    return churches.map((church) => this.toDomain(church));
   }
 
   async getById(churchId: string): Promise<Church> {
-    const church = this.churches.get(churchId);
+    const id = this.parseId(churchId);
+    if (id === null) {
+      throw new NotFoundException('Church not found');
+    }
+
+    const church = await this.prisma.church.findUnique({ where: { id } });
     if (!church) {
       throw new NotFoundException('Church not found');
     }
 
-    return church;
+    return this.toDomain(church);
   }
 
   async update(churchId: string, input: UpdateChurchInput): Promise<Church> {
-    const existing = await this.getById(churchId);
+    const id = this.parseId(churchId);
+    if (id === null) {
+      throw new NotFoundException('Church not found');
+    }
 
-    const updated: Church = {
-      ...existing,
-      ...input,
-      settings: { ...existing.settings, ...(input.settings ?? {}) },
-      updatedAt: new Date()
+    const existing = await this.prisma.church.findUnique({ where: { id } });
+    if (!existing) {
+      throw new NotFoundException('Church not found');
+    }
+
+    const data: Prisma.ChurchUpdateInput = {};
+
+    if (input.name !== undefined) {
+      data.name = input.name;
+    }
+
+    if (input.timezone !== undefined) {
+      data.timezone = input.timezone;
+    }
+
+    if (input.country !== undefined) {
+      data.country = this.toNullableString(input.country);
+    }
+
+    if (input.state !== undefined) {
+      data.state = this.toNullableString(input.state);
+    }
+
+    if (input.city !== undefined) {
+      data.city = this.toNullableString(input.city);
+    }
+
+    if (input.settings !== undefined) {
+      const mergedSettings = this.mergeSettings(existing.settings, input.settings);
+      if (mergedSettings !== null) {
+        data.settings = mergedSettings as Prisma.InputJsonValue;
+      }
+    }
+
+    if (Object.keys(data).length === 0) {
+      return this.toDomain(existing);
+    }
+
+    const updated = await this.prisma.church.update({
+      where: { id },
+      data
+    });
+
+    return this.toDomain(updated);
+  }
+
+  private toDomain(church: ChurchModel): Church {
+    return {
+      id: church.id.toString(),
+      name: church.name,
+      timezone: church.timezone,
+      country: church.country ?? undefined,
+      state: church.state ?? undefined,
+      city: church.city ?? undefined,
+      settings: this.normalizeSettings(church.settings),
+      createdAt: church.createdAt,
+      updatedAt: church.updatedAt
     };
+  }
 
-    this.churches.set(updated.id, updated);
-    return updated;
+  private prepareSettings(settings: unknown): Record<string, unknown> {
+    return this.normalizeIncomingSettings(settings);
+  }
+
+  private mergeSettings(
+    existing: Prisma.JsonValue | null | undefined,
+    updates: unknown
+  ): Record<string, unknown> | null {
+    const current = this.normalizeSettings(existing);
+    const incoming = this.normalizeIncomingSettings(updates);
+
+    if (Object.keys(incoming).length === 0) {
+      return null;
+    }
+
+    const merged = { ...current, ...incoming };
+    return this.areSettingsEqual(current, merged) ? null : merged;
+  }
+
+  private normalizeSettings(settings: Prisma.JsonValue | null | undefined): Record<string, unknown> {
+    if (!this.isPlainObject(settings)) {
+      return {};
+    }
+
+    return Object.fromEntries(Object.entries(settings as Record<string, unknown>));
+  }
+
+  private normalizeIncomingSettings(settings: unknown): Record<string, unknown> {
+    if (!this.isPlainObject(settings)) {
+      return {};
+    }
+
+    return Object.fromEntries(Object.entries(settings as Record<string, unknown>));
+  }
+
+  private areSettingsEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+
+    if (aKeys.length !== bKeys.length) {
+      return false;
+    }
+
+    return aKeys.every((key) => Object.is(a[key], b[key]));
+  }
+
+  private isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      Object.prototype.toString.call(value) === '[object Object]'
+    );
+  }
+
+  private toNullableString(value: string | null | undefined): string | null {
+    if (value === undefined || value === null) {
+      return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length === 0 ? null : trimmed;
+  }
+
+  private parseId(id: string): number | null {
+    if (typeof id !== 'string') {
+      return null;
+    }
+
+    const normalized = id.trim();
+    if (normalized.length === 0 || !/^[0-9]+$/.test(normalized)) {
+      return null;
+    }
+
+    const parsed = Number.parseInt(normalized, 10);
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+      return null;
+    }
+
+    return parsed;
   }
 }

--- a/apps/backend/src/modules/content/content.controller.ts
+++ b/apps/backend/src/modules/content/content.controller.ts
@@ -1,9 +1,18 @@
-import { Body, Controller, Get, Post, Put } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, Post, Put, Query } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import type { HomeContent, PaginatedResult, Sermon } from '@covenant-connect/shared';
 
 import { ContentService } from './content.service';
 import { HomeContentDto } from './dto/home-content.dto';
+
+type CreateSermonRequest = {
+  title: string;
+  description?: string | null;
+  preacher?: string | null;
+  date?: string | null;
+  mediaUrl?: string | null;
+  mediaType?: string | null;
+};
 
 @ApiTags('Content')
 @Controller('content')
@@ -23,13 +32,28 @@ export class ContentController {
     return this.content.updateHome(body);
   }
 
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'pageSize', required: false, type: Number, example: 25 })
   @Get('sermons')
-  listSermons(): Promise<PaginatedResult<Sermon>> {
-    return this.content.listSermons();
+  listSermons(
+    @Query('page') page = '1',
+    @Query('pageSize') pageSize = '25'
+  ): Promise<PaginatedResult<Sermon>> {
+    return this.content.listSermons({
+      page: Number.parseInt(page, 10),
+      pageSize: Number.parseInt(pageSize, 10)
+    });
   }
 
   @Post('sermons')
-  addSermon(@Body() sermon: Sermon): Promise<{ success: boolean }> {
-    return this.content.addSermon(sermon).then(() => ({ success: true }));
+  addSermon(@Body() body: CreateSermonRequest): Promise<Sermon> {
+    return this.content.addSermon({
+      title: body.title,
+      description: body.description ?? null,
+      preacher: body.preacher ?? null,
+      date: body.date ? new Date(body.date) : undefined,
+      mediaUrl: body.mediaUrl ?? null,
+      mediaType: body.mediaType ?? null
+    });
   }
 }

--- a/apps/backend/src/modules/content/content.module.ts
+++ b/apps/backend/src/modules/content/content.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 
+import { PrismaModule } from '../../prisma/prisma.module';
 import { ContentController } from './content.controller';
 import { ContentService } from './content.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [ContentController],
   providers: [ContentService],
   exports: [ContentService]

--- a/apps/backend/src/modules/content/content.service.spec.ts
+++ b/apps/backend/src/modules/content/content.service.spec.ts
@@ -1,0 +1,179 @@
+import { BadRequestException } from '@nestjs/common';
+import type { Sermon as PrismaSermon } from '@prisma/client';
+
+import { ContentService } from './content.service';
+import type { PrismaService } from '../../prisma/prisma.service';
+
+class InMemoryPrismaService {
+  private sequence = 1;
+  private readonly sermons: SermonRecord[] = [];
+
+  public readonly sermon = {
+    findMany: jest.fn(
+      async (
+        params: {
+          skip?: number;
+          take?: number;
+          orderBy?: { date?: 'asc' | 'desc' };
+        } = {}
+      ) => this.findMany(params)
+    ),
+    count: jest.fn(async () => this.sermons.length),
+    create: jest.fn(async ({ data }: { data: Record<string, unknown> }) => this.create(data))
+  };
+
+  private async findMany(params: {
+    skip?: number;
+    take?: number;
+    orderBy?: { date?: 'asc' | 'desc' };
+  }): Promise<PrismaSermon[]> {
+    const skip = params.skip ?? 0;
+    const take = params.take ?? this.sermons.length;
+    const orderBy = params.orderBy;
+
+    const sorted = [...this.sermons];
+    if (orderBy?.date === 'asc') {
+      sorted.sort((a, b) => a.date.getTime() - b.date.getTime());
+    } else if (orderBy?.date === 'desc') {
+      sorted.sort((a, b) => b.date.getTime() - a.date.getTime());
+    }
+
+    const slice = sorted.slice(skip, take ? skip + take : undefined);
+    return slice.map((record) => this.toModel(this.cloneRecord(record)));
+  }
+
+  private async create(data: Record<string, unknown>): Promise<PrismaSermon> {
+    const record: SermonRecord = {
+      id: this.sequence++,
+      title: (data.title as string) ?? 'Untitled Sermon',
+      description: (data.description as string | null | undefined) ?? null,
+      preacher: (data.preacher as string | null | undefined) ?? null,
+      date: this.normalizeDate(data.date),
+      mediaUrl: (data.mediaUrl as string | null | undefined) ?? null,
+      mediaType: (data.mediaType as string | null | undefined) ?? null
+    };
+
+    this.sermons.push(record);
+    return this.toModel(this.cloneRecord(record));
+  }
+
+  private normalizeDate(value: unknown): Date {
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      return new Date(value.getTime());
+    }
+
+    const parsed = typeof value === 'string' ? new Date(value) : null;
+    if (parsed && !Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+
+    return new Date();
+  }
+
+  private toModel(record: SermonRecord): PrismaSermon {
+    return {
+      id: record.id,
+      title: record.title,
+      description: record.description,
+      preacher: record.preacher,
+      date: record.date,
+      mediaUrl: record.mediaUrl,
+      mediaType: record.mediaType
+    };
+  }
+
+  private cloneRecord(record: SermonRecord): SermonRecord {
+    return {
+      ...record,
+      date: new Date(record.date.getTime())
+    };
+  }
+}
+
+type SermonRecord = {
+  id: number;
+  title: string;
+  description: string | null;
+  preacher: string | null;
+  date: Date;
+  mediaUrl: string | null;
+  mediaType: string | null;
+};
+
+describe('ContentService', () => {
+  let prisma: InMemoryPrismaService;
+  let service: ContentService;
+
+  beforeEach(() => {
+    prisma = new InMemoryPrismaService();
+    service = new ContentService(prisma as unknown as PrismaService);
+  });
+
+  it('returns paginated sermons sorted by most recent date', async () => {
+    const older = await service.addSermon({
+      title: 'Legacy Faithfulness',
+      date: new Date('2023-01-01T10:00:00Z'),
+      preacher: 'Rev. Grace',
+      mediaType: 'video',
+      mediaUrl: 'https://example.com/legacy'
+    });
+
+    const newer = await service.addSermon({
+      title: 'Renewed Hope',
+      date: new Date('2024-05-10T09:30:00Z'),
+      preacher: 'Pastor Daniel'
+    });
+
+    const result = await service.listSermons({ page: 1, pageSize: 1 });
+
+    expect(result.total).toBe(2);
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(1);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe(newer.id);
+    expect(result.data[0].title).toBe('Renewed Hope');
+
+    const secondPage = await service.listSermons({ page: 2, pageSize: 1 });
+    expect(secondPage.data[0].id).toBe(older.id);
+  });
+
+  it('trims optional strings and defaults missing values when creating sermons', async () => {
+    const created = await service.addSermon({
+      title: '  Hope Restored  ',
+      preacher: '  Pastor Micah  ',
+      description: '\nA message of renewal.\n',
+      mediaUrl: '   ',
+      mediaType: undefined,
+      date: undefined
+    });
+
+    expect(created.title).toBe('Hope Restored');
+    expect(created.preacher).toBe('Pastor Micah');
+    expect(created.description).toBe('A message of renewal.');
+    expect(created.mediaUrl).toBeNull();
+    expect(created.mediaType).toBeNull();
+    expect(created.date instanceof Date).toBe(true);
+  });
+
+  it('sanitizes invalid pagination input', async () => {
+    await service.addSermon({ title: 'First Sermon' });
+
+    const result = await service.listSermons({
+      page: Number.NaN,
+      pageSize: 500
+    });
+
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(100);
+    expect(result.total).toBe(1);
+  });
+
+  it('rejects attempts to create sermons without a valid title', async () => {
+    await expect(
+      service.addSermon({
+        title: '   ',
+        preacher: 'Pastor Lee'
+      })
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/apps/backend/src/modules/content/content.service.ts
+++ b/apps/backend/src/modules/content/content.service.ts
@@ -1,9 +1,21 @@
-import { Injectable } from '@nestjs/common';
-import type { HomeContent, PaginatedResult, Sermon } from '@covenant-connect/shared';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import type { HomeContent, PaginatedResult, Pagination, Sermon } from '@covenant-connect/shared';
+
+import { PrismaService } from '../../prisma/prisma.service';
+
+type CreateSermonInput = {
+  title: string;
+  description?: string | null;
+  preacher?: string | null;
+  date?: Date | null;
+  mediaUrl?: string | null;
+  mediaType?: string | null;
+};
 
 @Injectable()
 export class ContentService {
-  private readonly sermons: Sermon[] = [];
+  constructor(private readonly prisma: PrismaService) {}
+
   private homeContent: HomeContent = {
     heroTitle: 'Plan services and care pathways with ease',
     heroSubtitle:
@@ -32,16 +44,88 @@ export class ContentService {
     return this.homeContent;
   }
 
-  async listSermons(): Promise<PaginatedResult<Sermon>> {
+  async listSermons(pagination: Pagination = { page: 1, pageSize: 25 }): Promise<PaginatedResult<Sermon>> {
+    const page = this.normalizePage(pagination.page);
+    const pageSize = this.normalizePageSize(pagination.pageSize);
+    const skip = (page - 1) * pageSize;
+
+    const [records, total] = await Promise.all([
+      this.prisma.sermon.findMany({
+        skip,
+        take: pageSize,
+        orderBy: { date: 'desc' }
+      }),
+      this.prisma.sermon.count()
+    ]);
+
     return {
-      data: this.sermons,
-      total: this.sermons.length,
-      page: 1,
-      pageSize: this.sermons.length || 1
+      data: records,
+      total,
+      page,
+      pageSize
     };
   }
 
-  async addSermon(sermon: Sermon): Promise<void> {
-    this.sermons.push(sermon);
+  async addSermon(input: CreateSermonInput): Promise<Sermon> {
+    const created = await this.prisma.sermon.create({
+      data: {
+        title: this.requireTitle(input.title),
+        description: this.optionalString(input.description),
+        preacher: this.optionalString(input.preacher),
+        date: this.normalizeDate(input.date),
+        mediaUrl: this.optionalString(input.mediaUrl),
+        mediaType: this.optionalString(input.mediaType)
+      }
+    });
+
+    return created;
+  }
+
+  private requireTitle(title: string): string {
+    const normalized = this.optionalString(title);
+    if (!normalized) {
+      throw new BadRequestException('Title is required');
+    }
+
+    return normalized;
+  }
+
+  private optionalString(value: string | null | undefined): string | null {
+    if (value === undefined || value === null) {
+      return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length === 0 ? null : trimmed;
+  }
+
+  private normalizeDate(value: Date | null | undefined): Date {
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      return value;
+    }
+
+    return new Date();
+  }
+
+  private normalizePage(page: number | undefined): number {
+    if (typeof page !== 'number' || !Number.isFinite(page)) {
+      return 1;
+    }
+
+    const normalized = Math.trunc(page);
+    return normalized > 0 ? normalized : 1;
+  }
+
+  private normalizePageSize(pageSize: number | undefined): number {
+    if (typeof pageSize !== 'number' || !Number.isFinite(pageSize)) {
+      return 25;
+    }
+
+    const normalized = Math.trunc(pageSize);
+    if (normalized <= 0) {
+      return 25;
+    }
+
+    return Math.min(normalized, 100);
   }
 }

--- a/apps/backend/types/covenant-connect__shared.d.ts
+++ b/apps/backend/types/covenant-connect__shared.d.ts
@@ -116,12 +116,13 @@ declare module '@covenant-connect/shared' {
   };
 
   export type Sermon = {
-    id: string;
+    id: number;
     title: string;
-    speaker: string;
-    description?: string;
-    mediaUrl?: string;
-    recordedAt?: Date;
+    description: string | null;
+    preacher: string | null;
+    date: Date;
+    mediaUrl: string | null;
+    mediaType: string | null;
   };
 
   export type HomeContent = {

--- a/apps/backend/types/jest/index.d.ts
+++ b/apps/backend/types/jest/index.d.ts
@@ -2,6 +2,8 @@ declare global {
   interface JestMatchers {
     toEqual(expected: unknown): void;
     toBe(value: unknown): void;
+    toBeNull(): void;
+    toHaveLength(length: number): void;
     toHaveBeenCalledWith(...args: unknown[]): void;
     toHaveBeenCalledTimes(count: number): void;
     toHaveBeenCalled(): void;

--- a/apps/frontend/.eslintignore
+++ b/apps/frontend/.eslintignore
@@ -1,0 +1,1 @@
+lib/generated/

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -36,6 +36,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <Link className="transition hover:text-indigo-600" href="/donations">
                   Donations
                 </Link>
+                <Link className="transition hover:text-indigo-600" href="/solutions/wordpress-plugin">
+                  WordPress
+                </Link>
                 <Link className="transition hover:text-indigo-600" href="/prayer">
                   Prayer
                 </Link>

--- a/apps/frontend/app/page.test.tsx
+++ b/apps/frontend/app/page.test.tsx
@@ -41,6 +41,7 @@ describe('HomePage', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /launch admin console/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /review giving activity/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /explore wordpress plugin/i })).toBeInTheDocument();
     expect(screen.getAllByText('0')).toHaveLength(4);
   });
 

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -24,7 +24,8 @@ async function loadData() {
           { label: 'Launch admin console', url: '/dashboard' },
           { label: 'Browse events calendar', url: '/events' },
           { label: 'Review giving activity', url: '/donations' },
-          { label: 'Manage prayer follow-up', url: '/prayer' }
+          { label: 'Manage prayer follow-up', url: '/prayer' },
+          { label: 'Explore WordPress plugin', url: '/solutions/wordpress-plugin' }
         ]
       },
       report: {

--- a/apps/frontend/app/solutions/wordpress-plugin/page.test.tsx
+++ b/apps/frontend/app/solutions/wordpress-plugin/page.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import WordPressPluginPage from './page';
+
+describe('WordPressPluginPage', () => {
+  it('renders hero content and primary sections', () => {
+    render(<WordPressPluginPage />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: /publish ministry content in minutes/i
+      })
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('link', { name: /request download/i })).toHaveAttribute(
+      'href',
+      'mailto:support@covenantconnect.com?subject=WordPress%20Plugin%20Access'
+    );
+
+    expect(screen.getByText(/real-time content sync/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /three steps to launch/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /plugin support/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /frequently asked questions/i })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/app/solutions/wordpress-plugin/page.tsx
+++ b/apps/frontend/app/solutions/wordpress-plugin/page.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+
+const features = [
+  {
+    icon: '🔄',
+    title: 'Real-time content sync',
+    description:
+      'Display sermons, devotionals, and events from Covenant Connect inside WordPress without duplicating work across dashboards.'
+  },
+  {
+    icon: '🎨',
+    title: 'Theme-aware blocks',
+    description:
+      'Drop responsive embeds that inherit your existing typography, colours, and spacing so the plugin feels native on day one.'
+  },
+  {
+    icon: '🔐',
+    title: 'Secure token authentication',
+    description:
+      'Issue time-limited access tokens from the SaaS portal so editors can connect safely without sharing database credentials.'
+  }
+] as const;
+
+const launchSteps = [
+  {
+    title: 'Install',
+    details: 'Upload the plugin ZIP in WordPress or install directly from the marketplace.'
+  },
+  {
+    title: 'Connect',
+    details: 'Paste your SaaS API key and choose which site collections to sync.'
+  },
+  {
+    title: 'Publish',
+    details: 'Place sermon, event, or donation blocks on any page and let automated sync handle the rest.'
+  }
+] as const;
+
+const capabilities = [
+  'Embed sermon video and audio players with automatic fallbacks',
+  'Show curated event lists, calendars, and add-to-calendar buttons',
+  'Create donation callouts that route supporters to secure Paystack or Fincra checkouts',
+  'Capture prayer requests that post back to the SaaS pipeline in seconds'
+] as const;
+
+const operationalHighlights = [
+  {
+    title: 'Sync frequency',
+    description: 'Content sync runs every five minutes, and you can trigger an instant refresh from either dashboard.'
+  },
+  {
+    title: 'Staging friendly',
+    description: 'Safely test updates on staging domains before promoting them live with one-click promotion.'
+  },
+  {
+    title: 'Developer ready',
+    description: 'Filters and actions expose templates, caching, and custom field mapping for agencies.'
+  }
+] as const;
+
+const supportChannels = [
+  {
+    title: 'Documentation',
+    description: 'Step-by-step guides covering shortcodes, Gutenberg blocks, and theme overrides.'
+  },
+  {
+    title: 'Office hours',
+    description: 'Live weekly Q&A sessions with our product specialists to troubleshoot complex builds.'
+  },
+  {
+    title: 'Priority support',
+    description: 'Impact plan customers receive 2-hour response SLAs across chat and email.'
+  }
+] as const;
+
+const faqs = [
+  {
+    question: 'Does the plugin work with multisite?',
+    answer: 'Yes, each site can authenticate with its own API token and choose unique content feeds.'
+  },
+  {
+    question: 'Can developers extend the plugin?',
+    answer: 'Hooks and filters are available for custom taxonomies, templates, and caching strategies.'
+  },
+  {
+    question: 'How often does sync occur?',
+    answer: 'By default content updates every five minutes, and you can trigger an instant sync from the WordPress dashboard.'
+  }
+] as const;
+
+export const metadata = {
+  title: 'WordPress Plugin | Covenant Connect',
+  description:
+    'Embed synced sermons, events, and donation prompts on any WordPress site with the Covenant Connect plugin.'
+};
+
+export default function WordPressPluginPage(): React.ReactElement {
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-12">
+      <section className="rounded-3xl bg-gradient-to-br from-sky-500 via-indigo-500 to-purple-600 p-10 text-white shadow-xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-sky-100">WordPress integration</p>
+        <h1 className="mt-4 text-4xl font-semibold leading-tight md:text-5xl">
+          Publish ministry content in minutes
+        </h1>
+        <p className="mt-4 max-w-2xl text-lg text-sky-50">
+          Install the Covenant Connect WordPress plugin to sync sermons, events, and donation prompts straight from your SaaS
+          dashboard without copying and pasting.
+        </p>
+        <div className="mt-8 flex flex-wrap gap-4">
+          <a
+            className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-indigo-600 shadow transition hover:bg-indigo-50"
+            href="mailto:support@covenantconnect.com?subject=WordPress%20Plugin%20Access"
+          >
+            Request download
+          </a>
+          <a
+            className="inline-flex items-center justify-center rounded-full border border-white/30 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+            href="/dashboard"
+          >
+            Explore SaaS platform
+          </a>
+        </div>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-3">
+        {features.map((feature) => (
+          <article key={feature.title} className="rounded-2xl bg-white p-6 shadow-sm">
+            <span className="flex h-12 w-12 items-center justify-center rounded-full bg-indigo-50 text-2xl">
+              {feature.icon}
+            </span>
+            <h2 className="mt-4 text-xl font-semibold text-slate-900">{feature.title}</h2>
+            <p className="mt-2 text-sm text-slate-500">{feature.description}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <div className="rounded-2xl bg-white p-6 shadow-sm">
+          <h2 className="text-2xl font-semibold text-slate-900">Three steps to launch</h2>
+          <ol className="mt-6 space-y-4">
+            {launchSteps.map((step, index) => (
+              <li key={step.title} className="flex gap-4">
+                <span className="mt-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-indigo-50 text-base font-semibold text-indigo-600">
+                  {index + 1}
+                </span>
+                <div>
+                  <h3 className="text-lg font-semibold text-slate-900">{step.title}</h3>
+                  <p className="mt-1 text-sm text-slate-500">{step.details}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        <div className="rounded-2xl bg-white p-6 shadow-sm">
+          <h2 className="text-2xl font-semibold text-slate-900">What you can build</h2>
+          <p className="mt-2 text-sm text-slate-500">Drag-and-drop blocks make it easy to keep your website fresh.</p>
+          <ul className="mt-4 space-y-3 text-sm text-slate-600">
+            {capabilities.map((item) => (
+              <li key={item} className="flex items-start gap-3">
+                <span aria-hidden className="mt-1 inline-flex h-2 w-2 rounded-full bg-indigo-500" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-3">
+        {operationalHighlights.map((highlight) => (
+          <article key={highlight.title} className="rounded-2xl bg-white p-6 shadow-sm">
+            <h3 className="text-lg font-semibold text-slate-900">{highlight.title}</h3>
+            <p className="mt-2 text-sm text-slate-500">{highlight.description}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <div className="rounded-2xl bg-white p-6 shadow-sm">
+          <h2 className="text-2xl font-semibold text-slate-900">Plugin support</h2>
+          <div className="mt-4 grid gap-4 sm:grid-cols-3">
+            {supportChannels.map((channel) => (
+              <article key={channel.title} className="rounded-xl bg-indigo-50 p-4 text-indigo-900">
+                <h3 className="text-sm font-semibold uppercase tracking-wide">{channel.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-indigo-800">{channel.description}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+        <aside className="rounded-2xl bg-indigo-600 p-6 text-white shadow-lg">
+          <h2 className="text-2xl font-semibold">Need the SaaS backend?</h2>
+          <p className="mt-3 text-sm text-indigo-100">
+            Launch the full Covenant Connect platform to manage your content, donors, and teams with a single login.
+          </p>
+          <a
+            className="mt-6 inline-flex w-full items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-100"
+            href="/dashboard"
+          >
+            Start with SaaS
+          </a>
+        </aside>
+      </section>
+
+      <section className="rounded-2xl bg-white p-6 shadow-sm">
+        <h2 className="text-2xl font-semibold text-slate-900">Frequently asked questions</h2>
+        <div className="mt-6 space-y-4">
+          {faqs.map((faq) => (
+            <details key={faq.question} className="group rounded-xl border border-slate-200 p-4">
+              <summary className="flex cursor-pointer items-center justify-between gap-4 text-left text-sm font-semibold text-slate-900">
+                {faq.question}
+                <span className="text-lg text-indigo-500 transition group-open:rotate-45">+</span>
+              </summary>
+              <p className="mt-3 text-sm text-slate-600">{faq.answer}</p>
+            </details>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/docs/js-architecture.md
+++ b/docs/js-architecture.md
@@ -7,7 +7,7 @@ This document captures the initial structure for the JavaScript/TypeScript rewri
 | Area      | Selection | Rationale |
 |-----------|-----------|-----------|
 | Backend   | [NestJS](https://nestjs.com/) on Node 18+ | Decorator-driven modules mirror Flask blueprints, dependency injection keeps the code modular, and the ecosystem integrates well with Prisma, class-validator, and BullMQ. |
-| ORM       | Prisma (planned) | Prisma offers schema-first modelling with type-safe client generation. The current code ships with an in-memory repository layer that can be swapped for Prisma once the schema migration is authored. |
+| ORM       | Prisma | Prisma offers schema-first modelling with type-safe client generation. Accounts, churches, donations, and sermons already persist through Prisma models, with the remaining services staged for migration. |
 | Auth      | argon2 password hashing + pluggable OAuth handlers | Mirrors the existing local login and social sign-in flows while allowing future provider-specific strategies. |
 | Queue     | BullMQ/Redis (planned) | The in-memory task queue abstracts the interface required for follow-up scheduling, making it simple to drop in BullMQ workers later. |
 | Frontend  | Next.js 13 app router + Tailwind CSS | Provides hybrid SSG/SSR for marketing pages and authenticated dashboards, while Tailwind accelerates UI delivery. |
@@ -22,6 +22,8 @@ This document captures the initial structure for the JavaScript/TypeScript rewri
 ├── apps
 │   ├── backend             # NestJS API
 │   └── frontend            # Next.js web experience
+├── integrations
+│   └── wordpress-plugin    # Installable WordPress plugin that consumes the API
 └── packages
     └── shared              # Domain interfaces shared across the stack
 ```
@@ -49,7 +51,7 @@ apps/backend
 │       └── tasks/          # Background job queue abstraction
 ```
 
-Each module exposes a Nest `Module`, `Service`, and (where relevant) `Controller`. Today the services rely on in-memory stores to keep the initial commit lightweight; the method contracts align with Prisma models so the repository layer can swap to a real database with minimal churn.
+Each module exposes a Nest `Module`, `Service`, and (where relevant) `Controller`. Accounts, churches, donations, and the content module’s sermon endpoints already persist data through Prisma, while the remaining modules still use in-memory stores whose method contracts align with the Prisma models for a straightforward swap to the database.
 
 ### Frontend structure
 
@@ -58,6 +60,7 @@ apps/frontend
 ├── app/                    # Next.js app router routes
 │   ├── layout.tsx          # Global shell + font loading
 │   ├── page.tsx            # Marketing landing page with SSR data fetch
+│   ├── solutions/wordpress-plugin/page.tsx  # WordPress plugin marketing experience
 │   └── dashboard/page.tsx  # Staff dashboard view
 ├── lib/api.ts              # Thin typed fetch wrappers for backend endpoints
 ├── tailwind.config.ts      # Tailwind design tokens
@@ -65,7 +68,23 @@ apps/frontend
 └── app/globals.css         # Tailwind entry point + base styles
 ```
 
+The marketing surface for the WordPress integration now lives in the Next.js app (`/solutions/wordpress-plugin`), replacing the Flask-rendered landing page and moving more of the public experience into the TypeScript stack.
+
 All data fetching uses the shared API client which reads `NEXT_PUBLIC_API_BASE_URL`. When the backend is unavailable the UI falls back to placeholder content so the experience degrades gracefully during local development.
+
+### WordPress plugin
+
+```
+integrations/wordpress-plugin
+├── covenant-connect.php           # Plugin bootstrap and constants
+├── includes/
+│   ├── class-covenant-connect-api-client.php
+│   └── class-covenant-connect-plugin.php
+├── assets/style.css               # Theme-friendly frontend styles
+└── README.md                      # Installation and shortcode usage guide
+```
+
+The plugin registers admin settings so site owners can point WordPress at the Covenant Connect API, then exposes `[covenant_connect_sermons]` and `[covenant_connect_events]` shortcodes that render responsive listings. Responses are cached via WordPress transients to limit API calls, and the HTML inherits theme typography so churches can drop embeds into existing pages without bespoke styling.
 
 ## Follow-up work
 
@@ -75,5 +94,6 @@ All data fetching uses the shared API client which reads `NEXT_PUBLIC_API_BASE_U
 4. **Queue infrastructure** – Connect the tasks module to Redis-backed BullMQ workers and port scheduled jobs (KPI digests, follow-ups, automation runners).
 5. **Testing & CI** – Introduce Vitest/Jest suites that mirror the Python pytest coverage and configure GitHub Actions for linting, type-checking, and tests across the monorepo.
 6. **Deployment scripts** – Author Dockerfiles and Terraform/Helm manifests for the Node services, aligning with the deployment practices documented in `docs/deployment-runbook.md`.
+7. **WordPress polish** – Ship Gutenberg blocks and richer templating around the new shortcodes, plus automated packaging so the plugin can be distributed through managed releases.
 
 This scaffold provides a production-ready foundation while leaving room to iteratively port the remaining domain logic from the Flask application.

--- a/integrations/wordpress-plugin/README.md
+++ b/integrations/wordpress-plugin/README.md
@@ -1,0 +1,43 @@
+# Covenant Connect WordPress Bridge
+
+This directory contains an installable WordPress plugin that embeds sermons and
+upcoming events from your Covenant Connect instance.  The plugin ships with
+shortcodes that render responsive lists, along with an admin settings page to
+configure the API endpoint and optional bearer token.
+
+## Installation
+
+1. Run the NestJS backend (`apps/backend`) somewhere publicly accessible or
+   expose it through a tunnelling service during development.
+2. Copy the `integrations/wordpress-plugin` directory into a folder named
+   `covenant-connect` inside `wp-content/plugins` on your WordPress site.
+3. Activate **Covenant Connect Bridge** in the WordPress plugins dashboard.
+4. Navigate to **Settings → Covenant Connect** and provide the API base URL (for
+   example `https://api.example.com`) and, if required, a bearer token that the
+   NestJS deployment expects via the `Authorization` header.
+
+Once configured, place the following shortcodes in any page, post, or block:
+
+- `[covenant_connect_sermons limit="5" layout="cards" show_preacher="true" show_date="true"]`
+- `[covenant_connect_events limit="3" layout="list" show_location="true" show_time="false"]`
+
+Both shortcodes accept an optional `cache_minutes` attribute (defaults to `5`)
+so busy sites can cache responses locally without overloading the API.
+
+## Development notes
+
+- Styles live in `assets/style.css`; they intentionally use minimal selectors so
+  they inherit well from any WordPress theme.
+- The plugin caches rendered HTML using WordPress transients. Flush the cache by
+  deleting the relevant transient or updating the shortcode attributes.
+- Additional blocks and editor integrations can build on the existing API client
+  in `includes/class-covenant-connect-api-client.php`.
+
+Pack the plugin into a zip by running:
+
+```bash
+zip -r covenant-connect-wordpress.zip covenant-connect
+```
+
+from inside the `integrations/wordpress-plugin` directory, then upload the zip
+through WordPress.

--- a/integrations/wordpress-plugin/assets/style.css
+++ b/integrations/wordpress-plugin/assets/style.css
@@ -1,0 +1,90 @@
+.covenant-connect {
+  margin: 1.5rem 0;
+  font-family: inherit;
+}
+
+.covenant-connect__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.covenant-connect--cards .covenant-connect__list {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.covenant-connect__item {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  background: #ffffff;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.covenant-connect__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.covenant-connect__meta {
+  margin: 0 0 0.75rem;
+  font-size: 0.9375rem;
+  color: #475569;
+}
+
+.covenant-connect__description {
+  margin: 0 0 1rem;
+  color: #1f2937;
+  line-height: 1.5;
+}
+
+.covenant-connect__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 0.875rem;
+  border-radius: 9999px;
+  text-decoration: none;
+  background: linear-gradient(135deg, #2563eb, #9333ea);
+  color: #ffffff;
+  font-weight: 600;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.covenant-connect__button:hover,
+.covenant-connect__button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+}
+
+.covenant-connect__notice {
+  border-left: 4px solid #2563eb;
+  padding: 0.75rem 1rem;
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 0.5rem;
+  color: #1e3a8a;
+}
+
+@media (prefers-color-scheme: dark) {
+  .covenant-connect__item {
+    background: rgba(15, 23, 42, 0.75);
+    color: #f8fafc;
+    border-color: rgba(148, 163, 184, 0.2);
+  }
+
+  .covenant-connect__meta {
+    color: #cbd5f5;
+  }
+
+  .covenant-connect__description {
+    color: #e2e8f0;
+  }
+
+  .covenant-connect__notice {
+    background: rgba(37, 99, 235, 0.16);
+    color: #bfdbfe;
+  }
+}

--- a/integrations/wordpress-plugin/covenant-connect.php
+++ b/integrations/wordpress-plugin/covenant-connect.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Plugin Name: Covenant Connect Bridge
+ * Description: Embed sermons and events from the Covenant Connect API directly in WordPress pages.
+ * Version: 0.1.0
+ * Author: Covenant Connect
+ * License: GPLv2 or later
+ * Requires PHP: 7.4
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+if (! defined('COVENANT_CONNECT_PLUGIN_VERSION')) {
+    define('COVENANT_CONNECT_PLUGIN_VERSION', '0.1.0');
+}
+
+if (! defined('COVENANT_CONNECT_PLUGIN_DIR')) {
+    define('COVENANT_CONNECT_PLUGIN_DIR', plugin_dir_path(__FILE__));
+}
+
+if (! defined('COVENANT_CONNECT_PLUGIN_URL')) {
+    define('COVENANT_CONNECT_PLUGIN_URL', plugin_dir_url(__FILE__));
+}
+
+require_once COVENANT_CONNECT_PLUGIN_DIR . 'includes/class-covenant-connect-api-client.php';
+require_once COVENANT_CONNECT_PLUGIN_DIR . 'includes/class-covenant-connect-plugin.php';
+
+add_action(
+    'plugins_loaded',
+    static function (): void {
+        \CovenantConnect\Plugin::instance();
+    }
+);

--- a/integrations/wordpress-plugin/includes/class-covenant-connect-api-client.php
+++ b/integrations/wordpress-plugin/includes/class-covenant-connect-api-client.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace CovenantConnect;
+
+use WP_Error;
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Small HTTP client for calling the Covenant Connect REST API.
+ */
+class ApiClient
+{
+    /**
+     * @var string
+     */
+    private $baseUrl;
+
+    /**
+     * @var string
+     */
+    private $apiKey;
+
+    /**
+     * @param string $baseUrl
+     * @param string $apiKey
+     */
+    public function __construct($baseUrl, $apiKey = '')
+    {
+        $this->baseUrl = rtrim((string) $baseUrl, "/ ");
+        $this->apiKey  = (string) $apiKey;
+    }
+
+    /**
+     * Determine whether the client is configured with a base URL.
+     */
+    public function isConfigured()
+    {
+        return $this->baseUrl !== '';
+    }
+
+    /**
+     * Fetch recent sermons from the API.
+     *
+     * @param int $limit
+     * @return array|WP_Error
+     */
+    public function getSermons($limit = 5)
+    {
+        $params = array(
+            'page'     => 1,
+            'pageSize' => $this->normalizeLimit($limit),
+        );
+
+        $response = $this->request('content/sermons', $params);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        if (! isset($response['data']) || ! is_array($response['data'])) {
+            return new WP_Error('covenant_connect_invalid_response', __('The sermons response was not in the expected format.', 'covenant-connect'));
+        }
+
+        return $response['data'];
+    }
+
+    /**
+     * Fetch upcoming events from the API.
+     *
+     * @param int $limit
+     * @return array|WP_Error
+     */
+    public function getEvents($limit = 5)
+    {
+        $params = array(
+            'page'     => 1,
+            'pageSize' => $this->normalizeLimit($limit),
+        );
+
+        $response = $this->request('events', $params);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        if (! isset($response['data']) || ! is_array($response['data'])) {
+            return new WP_Error('covenant_connect_invalid_response', __('The events response was not in the expected format.', 'covenant-connect'));
+        }
+
+        return $response['data'];
+    }
+
+    /**
+     * Execute a GET request against the API.
+     *
+     * @param string $path
+     * @param array<string, scalar> $query
+     * @return array|WP_Error
+     */
+    private function request($path, array $query = array())
+    {
+        if (! $this->isConfigured()) {
+            return new WP_Error('covenant_connect_not_configured', __('Set the Covenant Connect API base URL before embedding content.', 'covenant-connect'));
+        }
+
+        $url = trailingslashit($this->baseUrl) . ltrim($path, '/');
+
+        if (! empty($query)) {
+            $url = add_query_arg($query, $url);
+        }
+
+        $response = wp_remote_get(
+            $url,
+            array(
+                'timeout' => 10,
+                'headers' => $this->buildHeaders(),
+            )
+        );
+
+        if (is_wp_error($response)) {
+            return new WP_Error('covenant_connect_network_error', $response->get_error_message(), $response->get_error_data());
+        }
+
+        $status = wp_remote_retrieve_response_code($response);
+        $body   = wp_remote_retrieve_body($response);
+
+        if ($status < 200 || $status >= 300) {
+            return new WP_Error('covenant_connect_http_error', sprintf(__('The Covenant Connect API responded with HTTP %d.', 'covenant-connect'), $status), array('body' => $body));
+        }
+
+        $decoded = json_decode($body, true);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            return new WP_Error('covenant_connect_json_error', __('Unable to decode the API response.', 'covenant-connect'), array('body' => $body));
+        }
+
+        return is_array($decoded) ? $decoded : array();
+    }
+
+    /**
+     * Build HTTP headers for API requests.
+     *
+     * @return array<string, string>
+     */
+    private function buildHeaders()
+    {
+        $headers = array(
+            'Accept' => 'application/json',
+        );
+
+        if ($this->apiKey !== '') {
+            $headers['Authorization'] = 'Bearer ' . $this->apiKey;
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Normalize a limit value so we do not accidentally request too much data.
+     *
+     * @param int $limit
+     * @return int
+     */
+    private function normalizeLimit($limit)
+    {
+        $value = (int) $limit;
+
+        if ($value <= 0) {
+            $value = 5;
+        }
+
+        return (int) min($value, 25);
+    }
+}

--- a/integrations/wordpress-plugin/includes/class-covenant-connect-plugin.php
+++ b/integrations/wordpress-plugin/includes/class-covenant-connect-plugin.php
@@ -1,0 +1,502 @@
+<?php
+
+namespace CovenantConnect;
+
+use WP_Error;
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * WordPress integration glue for Covenant Connect.
+ */
+class Plugin
+{
+    /**
+     * @var Plugin|null
+     */
+    private static $instance = null;
+
+    /**
+     * Retrieve the shared plugin instance.
+     */
+    public static function instance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct()
+    {
+        add_action('init', array($this, 'registerShortcodes'));
+        add_action('admin_menu', array($this, 'registerSettingsPage'));
+        add_action('admin_init', array($this, 'registerSettings'));
+        add_action('wp_enqueue_scripts', array($this, 'registerAssets'));
+    }
+
+    /**
+     * Register the front-end stylesheet.
+     */
+    public function registerAssets()
+    {
+        wp_register_style(
+            'covenant-connect',
+            COVENANT_CONNECT_PLUGIN_URL . 'assets/style.css',
+            array(),
+            COVENANT_CONNECT_PLUGIN_VERSION
+        );
+    }
+
+    /**
+     * Register shortcodes that surface Covenant Connect content.
+     */
+    public function registerShortcodes()
+    {
+        add_shortcode('covenant_connect_sermons', array($this, 'renderSermonsShortcode'));
+        add_shortcode('covenant_connect_events', array($this, 'renderEventsShortcode'));
+    }
+
+    /**
+     * Register plugin settings and option fields.
+     */
+    public function registerSettings()
+    {
+        register_setting(
+            'covenant_connect_settings',
+            'covenant_connect_api_base_url',
+            array(
+                'type'              => 'string',
+                'sanitize_callback' => array($this, 'sanitizeApiBaseUrl'),
+                'default'           => '',
+            )
+        );
+
+        register_setting(
+            'covenant_connect_settings',
+            'covenant_connect_api_key',
+            array(
+                'type'              => 'string',
+                'sanitize_callback' => array($this, 'sanitizeApiKey'),
+                'default'           => '',
+            )
+        );
+
+        add_settings_section(
+            'covenant_connect_api',
+            __('API Connection', 'covenant-connect'),
+            array($this, 'renderSettingsIntro'),
+            'covenant_connect_settings'
+        );
+
+        add_settings_field(
+            'covenant_connect_api_base_url',
+            __('API base URL', 'covenant-connect'),
+            array($this, 'renderApiBaseUrlField'),
+            'covenant_connect_settings',
+            'covenant_connect_api'
+        );
+
+        add_settings_field(
+            'covenant_connect_api_key',
+            __('API token (optional)', 'covenant-connect'),
+            array($this, 'renderApiKeyField'),
+            'covenant_connect_settings',
+            'covenant_connect_api'
+        );
+    }
+
+    /**
+     * Render the settings page in wp-admin.
+     */
+    public function registerSettingsPage()
+    {
+        add_options_page(
+            __('Covenant Connect', 'covenant-connect'),
+            __('Covenant Connect', 'covenant-connect'),
+            'manage_options',
+            'covenant-connect',
+            array($this, 'renderSettingsPage')
+        );
+    }
+
+    /**
+     * Display introductory text above the settings form.
+     */
+    public function renderSettingsIntro()
+    {
+        echo '<p>' . esc_html__('Provide your Covenant Connect API endpoint so this site can pull the latest sermons and events.', 'covenant-connect') . '</p>';
+    }
+
+    /**
+     * Render the API base URL field.
+     */
+    public function renderApiBaseUrlField()
+    {
+        $value = esc_attr(get_option('covenant_connect_api_base_url', ''));
+        echo '<input type="url" class="regular-text" name="covenant_connect_api_base_url" value="' . $value . '" placeholder="https://api.covenantconnect.example" />';
+    }
+
+    /**
+     * Render the API key field.
+     */
+    public function renderApiKeyField()
+    {
+        $value = esc_attr(get_option('covenant_connect_api_key', ''));
+        echo '<input type="text" class="regular-text" name="covenant_connect_api_key" value="' . $value . '" placeholder="Optional token for private deployments" />';
+    }
+
+    /**
+     * Draw the settings page markup.
+     */
+    public function renderSettingsPage()
+    {
+        if (! current_user_can('manage_options')) {
+            return;
+        }
+
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__('Covenant Connect', 'covenant-connect') . '</h1>';
+        echo '<form method="post" action="options.php">';
+        settings_fields('covenant_connect_settings');
+        do_settings_sections('covenant_connect_settings');
+        submit_button(__('Save changes', 'covenant-connect'));
+        echo '</form>';
+        echo '</div>';
+    }
+
+    /**
+     * Render the sermons shortcode output.
+     *
+     * @param array<string, mixed> $atts
+     */
+    public function renderSermonsShortcode($atts)
+    {
+        $attributes = shortcode_atts(
+            array(
+                'limit'         => 5,
+                'show_preacher' => 'true',
+                'show_date'     => 'true',
+                'layout'        => 'list',
+                'cache_minutes' => 5,
+            ),
+            $atts,
+            'covenant_connect_sermons'
+        );
+
+        return $this->renderContent(
+            'sermons',
+            (int) $attributes['limit'],
+            (int) $attributes['cache_minutes'],
+            $attributes
+        );
+    }
+
+    /**
+     * Render the events shortcode output.
+     *
+     * @param array<string, mixed> $atts
+     */
+    public function renderEventsShortcode($atts)
+    {
+        $attributes = shortcode_atts(
+            array(
+                'limit'         => 5,
+                'show_location' => 'true',
+                'show_time'     => 'true',
+                'layout'        => 'list',
+                'cache_minutes' => 5,
+            ),
+            $atts,
+            'covenant_connect_events'
+        );
+
+        return $this->renderContent(
+            'events',
+            (int) $attributes['limit'],
+            (int) $attributes['cache_minutes'],
+            $attributes
+        );
+    }
+
+    /**
+     * Shared rendering helper for sermons and events.
+     *
+     * @param 'sermons'|'events' $type
+     * @param int $limit
+     * @param int $cacheMinutes
+     * @param array<string, mixed> $attributes
+     * @return string
+     */
+    private function renderContent($type, $limit, $cacheMinutes, array $attributes)
+    {
+        $cacheMinutes = max(1, min((int) $cacheMinutes, 60));
+        $limit        = max(1, min((int) $limit, 25));
+        $cacheKey     = 'covenant_connect_' . $type . '_' . md5(wp_json_encode(array($limit, $attributes)));
+
+        $cached = get_transient($cacheKey);
+        if (false !== $cached) {
+            return (string) $cached;
+        }
+
+        $client = $this->makeClient();
+
+        if (! $client->isConfigured()) {
+            return $this->renderNotice(__('Configure the Covenant Connect API base URL in Settings → Covenant Connect before using this shortcode.', 'covenant-connect'));
+        }
+
+        if ('sermons' === $type) {
+            $response = $client->getSermons($limit);
+        } else {
+            $response = $client->getEvents($limit);
+        }
+
+        if ($response instanceof WP_Error) {
+            return $this->renderNotice($response->get_error_message());
+        }
+
+        if (! is_array($response) || empty($response)) {
+            return $this->renderNotice(__('No content is available yet. Once new records are published they will appear here automatically.', 'covenant-connect'));
+        }
+
+        wp_enqueue_style('covenant-connect');
+
+        if ('sermons' === $type) {
+            $html = $this->buildSermonsMarkup($response, $attributes);
+        } else {
+            $html = $this->buildEventsMarkup($response, $attributes);
+        }
+
+        set_transient($cacheKey, $html, $cacheMinutes * MINUTE_IN_SECONDS);
+
+        return $html;
+    }
+
+    /**
+     * Create a new API client with the configured credentials.
+     */
+    private function makeClient()
+    {
+        $baseUrl = (string) get_option('covenant_connect_api_base_url', '');
+        $apiKey  = (string) get_option('covenant_connect_api_key', '');
+
+        return new ApiClient($baseUrl, $apiKey);
+    }
+
+    /**
+     * Convert a truthy shortcode attribute to a boolean.
+     */
+    private function toBool($value)
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $normalized = strtolower((string) $value);
+
+        return in_array($normalized, array('1', 'true', 'yes', 'on'), true);
+    }
+
+    /**
+     * Produce HTML for the sermons listing.
+     *
+     * @param array<int, array<string, mixed>> $sermons
+     * @param array<string, mixed> $attributes
+     * @return string
+     */
+    private function buildSermonsMarkup(array $sermons, array $attributes)
+    {
+        $showPreacher = $this->toBool($attributes['show_preacher']);
+        $showDate     = $this->toBool($attributes['show_date']);
+        $layout       = $this->sanitizeLayout($attributes['layout']);
+
+        $items = array();
+
+        foreach ($sermons as $sermon) {
+            if (! is_array($sermon)) {
+                continue;
+            }
+
+            $title       = isset($sermon['title']) ? esc_html((string) $sermon['title']) : __('Untitled sermon', 'covenant-connect');
+            $description = isset($sermon['description']) ? wp_kses_post($sermon['description']) : '';
+            $preacher    = isset($sermon['preacher']) ? esc_html((string) $sermon['preacher']) : '';
+            $mediaUrl    = isset($sermon['mediaUrl']) ? esc_url((string) $sermon['mediaUrl']) : '';
+            $mediaType   = isset($sermon['mediaType']) ? esc_html((string) $sermon['mediaType']) : '';
+            $dateLabel   = isset($sermon['date']) ? $this->formatDate($sermon['date']) : '';
+
+            $metaParts = array();
+            if ($showDate && $dateLabel !== '') {
+                $metaParts[] = esc_html($dateLabel);
+            }
+            if ($showPreacher && $preacher !== '') {
+                $metaParts[] = esc_html($preacher);
+            }
+
+            $meta = '';
+            if (! empty($metaParts)) {
+                $meta = '<p class="covenant-connect__meta">' . esc_html(implode(' • ', $metaParts)) . '</p>';
+            }
+
+            $mediaButton = '';
+            if ($mediaUrl !== '') {
+                $buttonLabel = $mediaType !== '' ? sprintf(__('Open %s', 'covenant-connect'), $mediaType) : __('Watch / Listen', 'covenant-connect');
+                $mediaButton = '<p><a class="covenant-connect__button" href="' . $mediaUrl . '" target="_blank" rel="noopener noreferrer">' . esc_html($buttonLabel) . '</a></p>';
+            }
+
+            $items[] = '<li class="covenant-connect__item">'
+                . '<h3 class="covenant-connect__title">' . $title . '</h3>'
+                . $meta
+                . ($description !== '' ? '<p class="covenant-connect__description">' . $description . '</p>' : '')
+                . $mediaButton
+                . '</li>';
+        }
+
+        if (empty($items)) {
+            return $this->renderNotice(__('No sermons are available yet.', 'covenant-connect'));
+        }
+
+        $classes = 'covenant-connect covenant-connect--' . esc_attr($layout);
+        $list    = '<ul class="covenant-connect__list">' . implode('', $items) . '</ul>';
+
+        return '<div class="' . $classes . '">' . $list . '</div>';
+    }
+
+    /**
+     * Produce HTML for the events listing.
+     *
+     * @param array<int, array<string, mixed>> $events
+     * @param array<string, mixed> $attributes
+     * @return string
+     */
+    private function buildEventsMarkup(array $events, array $attributes)
+    {
+        $showLocation = $this->toBool($attributes['show_location']);
+        $showTime     = $this->toBool($attributes['show_time']);
+        $layout       = $this->sanitizeLayout($attributes['layout']);
+
+        $items = array();
+
+        foreach ($events as $event) {
+            if (! is_array($event)) {
+                continue;
+            }
+
+            $title       = isset($event['title']) ? esc_html((string) $event['title']) : __('Untitled event', 'covenant-connect');
+            $description = isset($event['description']) ? wp_kses_post($event['description']) : '';
+            $location    = isset($event['location']) ? esc_html((string) $event['location']) : '';
+            $startsAt    = isset($event['startsAt']) ? $this->formatDateTime($event['startsAt'], $showTime) : '';
+            $endsAt      = isset($event['endsAt']) ? $this->formatDateTime($event['endsAt'], $showTime) : '';
+
+            $metaParts = array();
+            if ($startsAt !== '') {
+                $metaParts[] = esc_html__('Starts', 'covenant-connect') . ': ' . esc_html($startsAt);
+            }
+            if ($endsAt !== '') {
+                $metaParts[] = esc_html__('Ends', 'covenant-connect') . ': ' . esc_html($endsAt);
+            }
+            if ($showLocation && $location !== '') {
+                $metaParts[] = esc_html__('Location', 'covenant-connect') . ': ' . esc_html($location);
+            }
+
+            $meta = '';
+            if (! empty($metaParts)) {
+                $meta = '<p class="covenant-connect__meta">' . implode('<br />', array_map('esc_html', $metaParts)) . '</p>';
+            }
+
+            $items[] = '<li class="covenant-connect__item">'
+                . '<h3 class="covenant-connect__title">' . $title . '</h3>'
+                . $meta
+                . ($description !== '' ? '<p class="covenant-connect__description">' . $description . '</p>' : '')
+                . '</li>';
+        }
+
+        if (empty($items)) {
+            return $this->renderNotice(__('There are no upcoming events right now. Check back soon!', 'covenant-connect'));
+        }
+
+        $classes = 'covenant-connect covenant-connect--' . esc_attr($layout);
+        $list    = '<ul class="covenant-connect__list">' . implode('', $items) . '</ul>';
+
+        return '<div class="' . $classes . '">' . $list . '</div>';
+    }
+
+    /**
+     * Convert layout hints to a known CSS modifier.
+     */
+    private function sanitizeLayout($layout)
+    {
+        $value = strtolower((string) $layout);
+
+        if (! in_array($value, array('list', 'cards'), true)) {
+            return 'list';
+        }
+
+        return $value;
+    }
+
+    /**
+     * Format a date string using the site locale.
+     */
+    private function formatDate($value)
+    {
+        $timestamp = strtotime((string) $value);
+
+        if (false === $timestamp) {
+            return '';
+        }
+
+        $format = get_option('date_format');
+
+        return date_i18n($format, $timestamp);
+    }
+
+    /**
+     * Format a datetime string using the site locale.
+     */
+    private function formatDateTime($value, $includeTime)
+    {
+        $timestamp = strtotime((string) $value);
+
+        if (false === $timestamp) {
+            return '';
+        }
+
+        $dateFormat = get_option('date_format');
+        $timeFormat = get_option('time_format');
+
+        if ($this->toBool($includeTime)) {
+            return date_i18n($dateFormat . ' ' . $timeFormat, $timestamp);
+        }
+
+        return date_i18n($dateFormat, $timestamp);
+    }
+
+    /**
+     * Render a user-facing notice.
+     */
+    private function renderNotice($message)
+    {
+        return '<div class="covenant-connect covenant-connect__notice">' . esc_html($message) . '</div>';
+    }
+
+    /**
+     * Sanitize the stored base URL.
+     */
+    public function sanitizeApiBaseUrl($value)
+    {
+        $sanitized = esc_url_raw((string) $value);
+
+        return $sanitized ?: '';
+    }
+
+    /**
+     * Sanitize the stored API key.
+     */
+    public function sanitizeApiKey($value)
+    {
+        return sanitize_text_field((string) $value);
+    }
+}


### PR DESCRIPTION
## Summary
- add a `/solutions/wordpress-plugin` Next.js landing page that mirrors the plugin marketing copy and CTA flow
- link the new page into the global navigation, extend the home fallback/test coverage, and document that the marketing site now lives in the TS stack
- ignore generated schema output during linting so the frontend CI passes without unsupported ESLint rules

## Testing
- pnpm --filter @covenant-connect/frontend lint
- pnpm --filter @covenant-connect/frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d1d39c0d6483339c41f058f0b7cd80