### PR TITLE
feat: harden migration cutover and worker runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ provided shortcodes.
 
 A Docker Compose configuration lives at `docker-compose.yml` for end-to-end
 local runs with PostgreSQL and Redis pre-wired. Run `docker compose up --build`
-to exercise the entire stack in containers.
+to exercise the entire stack in containers; the compose stack now launches the
+API, frontend, and BullMQ worker so background jobs execute just like they do in
+production.
 
 ## Scripts
 
@@ -71,6 +73,12 @@ The workspace root exposes convenience scripts that fan out to each package:
 * `pnpm run build` &mdash; build the shared package, backend, and frontend.
 * `pnpm run lint` / `pnpm run typecheck` / `pnpm run test` &mdash; quality gates for
   every workspace.
+* `pnpm run migrate:deploy` &mdash; apply the committed Prisma migrations to the
+  database configured via `DATABASE_URL`.
+* `pnpm run migrate:status` &mdash; display pending Prisma migrations for the
+  target database.
+* `pnpm run verify:migration` &mdash; run post-migration validation that checks key
+  tables and confirms no unapplied Prisma migrations remain.
 * `pnpm --filter @covenant-connect/backend generate:openapi` &mdash; regenerate the
   OpenAPI document after making controller or DTO changes.
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,6 +8,9 @@
   },
   "scripts": {
     "prisma:generate": "prisma generate",
+    "migrate:deploy": "prisma migrate deploy",
+    "migrate:status": "prisma migrate status",
+    "verify:migration": "ts-node --transpile-only src/scripts/verify-migration.ts",
     "build": "tsc -p tsconfig.build.json && node dist/src/scripts/generate-openapi.js",
     "generate:openapi": "node dist/src/scripts/generate-openapi.js",
     "dev": "ts-node-dev --respawn --transpile-only src/main.ts",

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -2,20 +2,32 @@ import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
-async function main(): Promise<void> {
+async function seedSettings(): Promise<void> {
   await prisma.settings.upsert({
     where: { id: 1 },
-    update: {},
+    update: {
+      businessName: 'Covenant Connect',
+      themePreference: 'dark'
+    },
     create: {
       id: 1,
       businessName: 'Covenant Connect',
       themePreference: 'dark'
     }
   });
+}
 
+async function seedChurch(): Promise<void> {
   await prisma.church.upsert({
     where: { id: 1 },
-    update: {},
+    update: {
+      name: 'Covenant Connect Church',
+      address: '123 Covenant Way',
+      timezone: 'America/New_York',
+      country: 'USA',
+      state: 'NY',
+      city: 'New York'
+    },
     create: {
       id: 1,
       name: 'Covenant Connect Church',
@@ -24,13 +36,21 @@ async function main(): Promise<void> {
       country: 'USA',
       state: 'NY',
       city: 'New York'
-     main
     }
   });
+}
 
+async function seedSampleSermon(): Promise<void> {
   await prisma.sermon.upsert({
     where: { id: 1 },
-    update: {},
+    update: {
+      title: 'Welcome Home Sunday',
+      preacher: 'Pastor Alicia Turner',
+      description: 'Kick off the new season with a message of belonging and mission.',
+      date: new Date('2024-01-07T15:00:00Z'),
+      mediaUrl: 'https://media.covenantconnect.example/sermons/welcome-home',
+      mediaType: 'video'
+    },
     create: {
       id: 1,
       title: 'Welcome Home Sunday',
@@ -39,12 +59,20 @@ async function main(): Promise<void> {
       date: new Date('2024-01-07T15:00:00Z'),
       mediaUrl: 'https://media.covenantconnect.example/sermons/welcome-home',
       mediaType: 'video'
-    main
     }
   });
 }
 
+async function main(): Promise<void> {
+  await seedSettings();
+  await seedChurch();
+  await seedSampleSermon();
+}
+
 main()
+  .then(() => {
+    console.info('Database seeded with baseline Covenant Connect records.');
+  })
   .catch((error) => {
     console.error('Failed to seed database', error);
     process.exitCode = 1;

--- a/apps/backend/src/modules/health/health.indicator.ts
+++ b/apps/backend/src/modules/health/health.indicator.ts
@@ -1,14 +1,139 @@
 import { Injectable } from '@nestjs/common';
-import { HealthIndicator, HealthIndicatorFunction } from '@nestjs/terminus';
+import { ConfigService } from '@nestjs/config';
+import {
+  HealthIndicator,
+  type HealthIndicatorFunction,
+  type HealthIndicatorResult
+} from '@nestjs/terminus';
+import Redis from 'ioredis';
+
+import { PrismaService } from '../../prisma/prisma.service';
+
+type QueueConfig = {
+  driver: 'redis' | 'memory';
+  redisUrl: string | null;
+};
+
+type RedisConnection = {
+  connect(): Promise<void>;
+  ping(): Promise<string>;
+  quit(): Promise<unknown>;
+  disconnect?(reconnect?: boolean): void;
+};
 
 @Injectable()
 export class HealthIndicatorService extends HealthIndicator {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly configService: ConfigService
+  ) {
+    super();
+  }
+
   isAlive: HealthIndicatorFunction = async () => {
     return this.getStatus('api', true);
   };
 
   isReady: HealthIndicatorFunction = async () => {
-    // TODO: add datastore and queue probes when wiring infrastructure.
-    return this.getStatus('dependencies', true);
+    const [database, queue] = await Promise.all([this.checkDatabase(), this.checkQueue()]);
+    return { ...database, ...queue };
   };
+
+  private async checkDatabase(): Promise<HealthIndicatorResult> {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+    } catch (error) {
+      return this.getStatus('database', false, {
+        message: (error as Error).message ?? 'Unable to connect to PostgreSQL'
+      });
+    }
+
+    try {
+      const result = await this.prisma.$queryRaw<{ pending: bigint }[]>`
+        SELECT COUNT(*)::bigint AS pending
+        FROM "_prisma_migrations"
+        WHERE finished_at IS NULL
+      `;
+
+      const pendingMigrations = this.parseCount(result[0]?.pending);
+      const isHealthy = pendingMigrations === 0;
+
+      return this.getStatus('database', isHealthy, {
+        pendingMigrations
+      });
+    } catch (error) {
+      return this.getStatus('database', false, {
+        message: 'Failed to inspect Prisma migration metadata',
+        detail: (error as Error).message ?? String(error)
+      });
+    }
+  }
+
+  private async checkQueue(): Promise<HealthIndicatorResult> {
+    const queueConfig = this.resolveQueueConfig();
+    const driver = queueConfig.driver;
+
+    if (driver !== 'redis') {
+      return this.getStatus('queue', true, { driver });
+    }
+
+    if (!queueConfig.redisUrl) {
+      return this.getStatus('queue', false, {
+        driver,
+        message: 'Redis URL missing from configuration'
+      });
+    }
+
+    const client = new Redis(queueConfig.redisUrl, {
+      lazyConnect: true,
+      maxRetriesPerRequest: 1
+    }) as unknown as RedisConnection;
+
+    let isConnected = false;
+
+    try {
+      await client.connect();
+      isConnected = true;
+      const startedAt = Date.now();
+      await client.ping();
+      const latencyMs = Date.now() - startedAt;
+
+      return this.getStatus('queue', true, { driver, latencyMs });
+    } catch (error) {
+      return this.getStatus('queue', false, {
+        driver,
+        message: (error as Error).message ?? 'Unable to connect to Redis'
+      });
+    } finally {
+      if (isConnected) {
+        await client.quit().catch(() => undefined);
+      } else {
+        const disconnect = client.disconnect;
+        if (typeof disconnect === 'function') {
+          disconnect.call(client);
+        }
+      }
+    }
+  }
+
+  private resolveQueueConfig(): QueueConfig {
+    const config = this.configService.get<QueueConfig>('automation.queue');
+    const driver = config?.driver ?? 'memory';
+    const redisUrl =
+      config?.redisUrl ??
+      this.configService.get<string>('application.redisUrl') ??
+      process.env.REDIS_URL ??
+      null;
+
+    return { driver, redisUrl };
+  }
+
+  private parseCount(value: unknown): number {
+    if (typeof value === 'bigint') {
+      return Number(value);
+    }
+
+    const parsed = Number(value ?? 0);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
 }

--- a/apps/backend/src/scripts/verify-migration.ts
+++ b/apps/backend/src/scripts/verify-migration.ts
@@ -1,0 +1,99 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+type TableCheck = {
+  label: string;
+  query: () => Promise<number>;
+};
+
+async function ensureConnection(): Promise<void> {
+  await prisma.$queryRaw`SELECT 1`;
+}
+
+async function getPendingMigrationCount(): Promise<number> {
+  const result = await prisma.$queryRaw<{ pending: bigint }[]>`
+    SELECT COUNT(*)::bigint AS pending
+    FROM "_prisma_migrations"
+    WHERE finished_at IS NULL
+  `;
+
+  const [row] = result;
+  if (!row) {
+    return 0;
+  }
+
+  const value = typeof row.pending === 'bigint' ? Number(row.pending) : Number(row.pending ?? 0);
+  return Number.isFinite(value) ? value : 0;
+}
+
+async function runTableChecks(): Promise<boolean> {
+  const tables: TableCheck[] = [
+    { label: 'users', query: () => prisma.user.count() },
+    { label: 'members', query: () => prisma.member.count() },
+    { label: 'donations', query: () => prisma.donation.count() },
+    { label: 'events', query: () => prisma.event.count() },
+    { label: 'prayerRequests', query: () => prisma.prayerRequest.count() },
+    { label: 'volunteerAssignments', query: () => prisma.volunteerAssignment.count() }
+  ];
+
+  let hasError = false;
+
+  for (const table of tables) {
+    try {
+      const count = await table.query();
+      console.info(`✔ ${table.label}: ${count} record(s)`);
+    } catch (error) {
+      console.error(`✖ Failed to query ${table.label}: ${(error as Error).message}`);
+      hasError = true;
+    }
+  }
+
+  return hasError;
+}
+
+async function main(): Promise<void> {
+  console.info('Running Prisma migration verification...');
+  let hasFailures = false;
+
+  try {
+    await ensureConnection();
+    console.info('✔ Database connection established');
+  } catch (error) {
+    console.error('✖ Unable to connect to database via Prisma:', (error as Error).message);
+    hasFailures = true;
+  }
+
+  if (!hasFailures) {
+    try {
+      const pendingMigrations = await getPendingMigrationCount();
+      if (pendingMigrations === 0) {
+        console.info('✔ No pending Prisma migrations detected');
+      } else {
+        console.warn(`⚠️ ${pendingMigrations} pending Prisma migration(s) detected`);
+        hasFailures = true;
+      }
+    } catch (error) {
+      console.error('✖ Unable to inspect Prisma migration metadata:', (error as Error).message);
+      hasFailures = true;
+    }
+  }
+
+  const tableFailures = await runTableChecks();
+  if (tableFailures) {
+    hasFailures = true;
+  }
+
+  if (hasFailures) {
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error('Unexpected error while verifying Prisma migration state:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -27,6 +27,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "covenant-connect.fullname" . }}-backend
 {{- end -}}
 
+{{- define "covenant-connect.workerName" -}}
+{{ include "covenant-connect.fullname" . }}-worker
+{{- end -}}
+
 {{- define "covenant-connect.frontendName" -}}
 {{ include "covenant-connect.fullname" . }}-frontend
 {{- end -}}

--- a/deploy/helm/templates/worker-deployment.yaml
+++ b/deploy/helm/templates/worker-deployment.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.worker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "covenant-connect.workerName" . }}
+  labels:
+    {{- include "covenant-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "covenant-connect.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "covenant-connect.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: worker
+          image: {{ printf "%s:%s" .Values.worker.image.repository .Values.worker.image.tag | quote }}
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy | default .Values.backend.image.pullPolicy }}
+          command: ["node", "dist/src/task-worker.main.js"]
+          env:
+            - name: APP_VERSION
+              value: {{ default .Chart.AppVersion .Values.worker.env.APP_VERSION | quote }}
+            {{- range $key, $value := .Values.worker.env }}
+            {{- if ne $key "APP_VERSION" }}
+            - name: {{ $key }}
+              value: {{ tpl (printf "%v" $value) $ | quote }}
+            {{- end }}
+            {{- end }}
+            {{- range $key, $_ := .Values.backend.secretEnv }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "covenant-connect.backendSecretName" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -49,6 +49,19 @@ backend:
     KPI_DIGEST_CRON: "0 7 * * 1"
     FOLLOW_UP_CRON: "0 */6 * * *"
 
+worker:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ghcr.io/example/covenant-connect/backend
+    tag: latest
+    pullPolicy: IfNotPresent
+  env:
+    APP_NAME: Covenant Connect Worker
+    NODE_ENV: production
+    QUEUE_DRIVER: redis
+  resources: {}
+
 frontend:
   replicaCount: 2
   image:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,30 @@ services:
     ports:
       - '8000:8000'
 
+  worker:
+    build:
+      context: .
+      dockerfile: apps/backend/Dockerfile
+      args:
+        APP_VERSION: local
+    image: covenant-connect/backend:local
+    command: ['node', 'dist/src/task-worker.main.js']
+    environment:
+      APP_NAME: Covenant Connect Worker
+      APP_VERSION: local
+      NODE_ENV: production
+      DATABASE_URL: postgresql://covenant_connect:covenantconnect@db:5432/covenant_connect?schema=public
+      REDIS_URL: redis://redis:6379/0
+      QUEUE_DRIVER: redis
+      SESSION_SECRET: localdevsupersecret
+      STORAGE_DRIVER: local
+      LOCAL_STORAGE_DIR: /tmp/uploads
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
   frontend:
     build:
       context: .

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -1,0 +1,130 @@
+# SQLAlchemy to Prisma migration and cutover plan
+
+This runbook codifies the steps required to migrate production data off the
+legacy SQLAlchemy/Flask stack and cut over to the NestJS/Prisma services that
+now power Covenant Connect. It assumes the Prisma schema remains aligned with
+the historic PostgreSQL tables and focuses on orchestrating a safe migration,
+validating data, enabling third-party integrations, and performing the final
+service swap.
+
+## 1. Pre-migration checklist
+
+1. **Freeze change windows**
+   - Announce the migration window and place the Flask application in read-only
+     mode (disable writes or schedule downtime).
+2. **Capture database and secrets backups**
+   - Take a full PostgreSQL base backup (`pg_dump --format=custom`) and verify it
+     restores in a staging environment.
+   - Export current `.env` secrets so OAuth, payments, and queue credentials can
+     be referenced when populating the new environment.
+3. **Provision staging environments**
+   - Stand up staging copies of PostgreSQL and Redis using the Helm chart or the
+     Docker Compose stack so smoke tests can be rehearsed ahead of the production
+     cutover.
+
+## 2. Database schema migration
+
+1. **Snapshot the live schema**
+   - Use Prisma's diff tooling to capture a baseline migration against the
+     existing SQLAlchemy-managed schema:
+
+     ```bash
+     # Point DATABASE_URL at a readonly replica or a production clone
+     pnpm --filter @covenant-connect/backend prisma migrate diff \
+       --from-url "$DATABASE_URL" \
+       --to-schema-datamodel apps/backend/prisma/schema.prisma \
+       --script > prisma-migration.sql
+     ```
+
+   - Review the generated SQL to confirm only Prisma metadata tables are added
+     (e.g. `_prisma_migrations`).
+2. **Create the initial Prisma migration**
+   - Apply the diff to a staging database and capture it as the "init" migration
+     if it has not already been committed (`20250922022205_init`).
+3. **Replay historical migrations**
+   - Ensure any follow-up migrations (integration settings, email providers,
+     church profile extensions) are present in `apps/backend/prisma/migrations`
+     and run `pnpm --filter @covenant-connect/backend prisma migrate deploy` in
+     staging until Prisma reports the database is up to date.
+4. **Validate data parity**
+   - Run aggregate comparisons between the Python ORM and Prisma:
+     - Row counts per table (`SELECT count(*) FROM users;` etc.).
+     - Spot-check high-value entities (members, donations, events).
+   - Use Prisma scripts to sanity-check the data once connected to staging.
+
+## 3. Production migration execution
+
+1. **Schedule downtime** (if zero-downtime dual writes are unavailable) and take
+   a fresh PostgreSQL snapshot immediately before applying migrations.
+2. **Run migrations**
+
+   ```bash
+   # With DATABASE_URL pointed at production and SHADOW_DATABASE_URL unset
+   pnpm --filter @covenant-connect/backend prisma migrate deploy
+   ```
+
+   - Prisma will create the `_prisma_migrations` table and mark historical steps
+     as applied without mutating existing records.
+3. **Warm Prisma client caches**
+   - Run `pnpm --filter @covenant-connect/backend prisma:generate` so the latest
+     Prisma client is baked into the backend image.
+4. **Smoke tests**
+   - Hit `/health/ready` on the Nest API and load key queries (accounts,
+     donations, events, prayer) to confirm data resolves via Prisma.
+
+## 4. Third-party integration enablement
+
+1. **OAuth providers**
+   - Populate `GOOGLE_*`, `FACEBOOK_*`, and `APPLE_*` secrets so the Nest
+     `GoogleOAuthProvider`, `FacebookOAuthProvider`, and `AppleOAuthProvider` can
+     issue authorization URLs and exchange tokens.【F:apps/backend/src/modules/auth/auth.module.ts†L6-L32】【F:apps/backend/src/modules/auth/providers/google.provider.ts†L1-L111】
+   - Use staging to walk through end-to-end sign-ins, verifying new `AccountProvider`
+     rows appear in Prisma.
+2. **Payment gateways**
+   - Configure Stripe, Paystack, Fincra, and Flutterwave keys in the backend
+     secret. Each provider implements the shared payment interface and calls the
+     live APIs for initialization, verification, and refunds.【F:apps/backend/src/modules/donations/donations.module.ts†L1-L39】【F:apps/backend/src/modules/donations/providers/stripe.provider.ts†L1-L101】
+   - Run provider-specific smoke tests (test cards, sandbox references) before
+     pointing production webhooks at the Nest API (`/donations/providers/*`).
+3. **Queues and automation**
+   - Ensure Redis connectivity (`REDIS_URL`) is available so the `TasksService`
+     can create BullMQ queues with retry and repeat schedules.【F:apps/backend/src/modules/tasks/tasks.service.ts†L1-L158】
+   - Start the worker entry point (`node dist/src/task-worker.main.js`) alongside
+     the API to process prayer notifications, KPI digests, and automation jobs.【F:apps/backend/src/modules/tasks/tasks.module.ts†L1-L24】
+
+## 5. Cutover from Python services
+
+1. **Deploy the Node services**
+   - Build and publish the backend/frontend Docker images via CI, then deploy
+     them with `deploy/helm` using production values for secrets, image tags, and
+     ingress settings.【F:docs/deployment-runbook.md†L1-L118】
+2. **Dual-run verification**
+   - Keep the Flask application online in read-only mode while directing a pilot
+     slice of traffic (internal staff) to the Next.js UI and Nest API.
+   - Monitor logs, queue throughput, and payment provider dashboards for parity
+     issues.
+3. **Switch primary traffic**
+   - Update DNS, load balancer rules, or ingress routes so all user traffic hits
+     the Node services.
+   - Remove read-only restrictions once the new stack is fully serving writes.
+4. **Decommission Python stack**
+   - After a stability window, archive the Flask containers and revoke unused
+     secrets. Keep snapshots for rollback until the migration is declared
+     complete.
+
+## 6. Rollback strategy
+
+- If Prisma migrations introduce issues, stop the Nest services and restore the
+  pre-migration PostgreSQL snapshot. Because Prisma only adds metadata tables,
+  restoration is a straightforward database rollback.
+- Re-enable the Flask application in read/write mode and communicate the delay.
+- Address root causes in staging before re-attempting the migration.
+
+## 7. Post-cutover tasks
+
+- Update monitoring dashboards and alerts to point at the Nest API and BullMQ
+  worker metrics.
+- Transfer ownership of OAuth/webhook endpoints with the respective providers so
+  future rotations do not reference the Python hosts.
+- Schedule a follow-up retrospective to capture lessons learned and validate that
+  all admin workflows now run against the Node services (`apps/frontend/app/admin/*`).

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "typecheck": "npm run typecheck --workspaces",
     "test": "npm run test --workspaces",
     "prisma:generate": "pnpm --filter @covenant-connect/backend prisma:generate",
+    "migrate:deploy": "pnpm --filter @covenant-connect/backend migrate:deploy",
+    "migrate:status": "pnpm --filter @covenant-connect/backend migrate:status",
+    "verify:migration": "pnpm --filter @covenant-connect/backend verify:migration",
     "postinstall": "pnpm run prisma:generate"
   }
 }


### PR DESCRIPTION
## Summary
- extend the readiness indicator to verify Prisma migrations and Redis connectivity before serving traffic
- add a reusable Prisma migration verification script, expose migrate commands, and fix the baseline seed data
- ship the BullMQ worker in docker-compose and the Helm chart with supporting docs for the cutover

## Testing
- pnpm --filter @covenant-connect/backend lint
- pnpm --filter @covenant-connect/backend typecheck
- pnpm --filter @covenant-connect/backend test

------
https://chatgpt.com/codex/tasks/task_e_68d3c6b15bec8333b51f627e391b54b6