### PR TITLE
Add ESLint ignore for generated Prisma client

### DIFF
--- a/packages/shared/.eslintignore
+++ b/packages/shared/.eslintignore
@@ -1,0 +1,1 @@
+src/generated/


### PR DESCRIPTION
## Summary
- add an .eslintignore file for the shared package to ignore generated Prisma client files during linting

## Testing
- pnpm --filter @covenant-connect/shared lint

------
https://chatgpt.com/codex/tasks/task_e_68d43b250a408333807050d7324e67df