### PR TITLE
Handle missing backend workspace during postinstall

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -8,6 +8,7 @@ FROM base AS deps
 COPY package.json ./
 COPY apps/backend/package.json ./apps/backend/package.json
 COPY packages/shared/package.json ./packages/shared/package.json
+COPY scripts/postinstall.js ./scripts/postinstall.js
 COPY apps/backend/prisma ./apps/backend/prisma
 RUN npm install
 

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -7,6 +7,7 @@ FROM base AS deps
 COPY package.json ./
 COPY apps/frontend/package.json ./apps/frontend/package.json
 COPY packages/shared/package.json ./packages/shared/package.json
+COPY scripts/postinstall.js ./scripts/postinstall.js
 RUN npm install
 
 FROM deps AS build

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "migrate:deploy": "npm run migrate:deploy --workspace=@covenant-connect/backend",
     "migrate:status": "npm run migrate:status --workspace=@covenant-connect/backend",
     "verify:migration": "npm run verify:migration --workspace=@covenant-connect/backend",
-    "postinstall": "npm run prisma:generate --workspace=@covenant-connect/backend",
+    "postinstall": "node scripts/postinstall.js",
     "package:wordpress": "npm run package --workspace=@covenant-connect/wordpress-plugin"
   }
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -13,11 +13,7 @@ if (!existsSync(workspaceManifest)) {
   process.exit(0);
 }
 
-const prismaArgs = [
-  'run',
-  'prisma:generate',
-  '--workspace=@covenant-connect/backend'
-];
+const backendWorkspaceDir = path.dirname(workspaceManifest);
 
 const npmExec = process.env.npm_execpath;
 
@@ -26,13 +22,16 @@ let args;
 
 if (npmExec) {
   command = process.execPath;
-  args = [npmExec, ...prismaArgs];
+  args = [npmExec, 'run', 'prisma:generate'];
 } else {
   command = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-  args = prismaArgs;
+  args = ['run', 'prisma:generate'];
 }
 
-const result = spawnSync(command, args, { stdio: 'inherit' });
+const result = spawnSync(command, args, {
+  stdio: 'inherit',
+  cwd: backendWorkspaceDir
+});
 
 if (result.error) {
   console.error(result.error);

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,22 @@
+const { existsSync } = require('fs');
+const { spawnSync } = require('child_process');
+
+const workspacePath = 'apps/backend/package.json';
+
+if (!existsSync(workspacePath)) {
+  console.log('Skipping backend prisma generate: workspace not present.');
+  process.exit(0);
+}
+
+const result = spawnSync(
+  'npm',
+  ['run', 'prisma:generate', '--workspace=@covenant-connect/backend'],
+  {
+    stdio: 'inherit',
+    shell: process.platform === 'win32'
+  }
+);
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,21 +1,42 @@
 const { existsSync } = require('fs');
+const path = require('path');
 const { spawnSync } = require('child_process');
 
-const workspacePath = 'apps/backend/package.json';
+const workspaceManifest = path.resolve(
+  __dirname,
+  '..',
+  'apps/backend/package.json'
+);
 
-if (!existsSync(workspacePath)) {
+if (!existsSync(workspaceManifest)) {
   console.log('Skipping backend prisma generate: workspace not present.');
   process.exit(0);
 }
 
-const result = spawnSync(
-  'npm',
-  ['run', 'prisma:generate', '--workspace=@covenant-connect/backend'],
-  {
-    stdio: 'inherit',
-    shell: process.platform === 'win32'
-  }
-);
+const prismaArgs = [
+  'run',
+  'prisma:generate',
+  '--workspace=@covenant-connect/backend'
+];
+
+const npmExec = process.env.npm_execpath;
+
+let command;
+let args;
+
+if (npmExec) {
+  command = process.execPath;
+  args = [npmExec, ...prismaArgs];
+} else {
+  command = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  args = prismaArgs;
+}
+
+const result = spawnSync(command, args, { stdio: 'inherit' });
+
+if (result.error) {
+  console.error(result.error);
+}
 
 if (result.status !== 0) {
   process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- replace the root postinstall command with a Node helper script
- skip running backend Prisma generation when the backend workspace package.json is not available

## Testing
- node scripts/postinstall.js

------
https://chatgpt.com/codex/tasks/task_e_68d4b7d1a2cc83339eda016df4bca96f