### PR TITLE
Handle missing backend workspace in postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,17 +9,17 @@
     "integrations/wordpress-plugin"
   ],
   "scripts": {
-    "prebuild": "npm run prisma:generate --workspace=@covenant-connect/backend",
+    "prebuild": "node scripts/run-backend-script.js prisma:generate",
     "build": "npm run build --workspaces",
     "dev": "npm run dev -w apps/backend",
     "lint": "npm run lint --workspaces",
     "typecheck": "npm run typecheck --workspaces",
     "test": "npm run test --workspaces",
-    "prisma:generate": "npm run prisma:generate --workspace=@covenant-connect/backend",
-    "migrate:deploy": "npm run migrate:deploy --workspace=@covenant-connect/backend",
-    "migrate:status": "npm run migrate:status --workspace=@covenant-connect/backend",
-    "verify:migration": "npm run verify:migration --workspace=@covenant-connect/backend",
-    "postinstall": "npm run prisma:generate --workspace=@covenant-connect/backend",
+    "prisma:generate": "node scripts/run-backend-script.js prisma:generate",
+    "migrate:deploy": "node scripts/run-backend-script.js migrate:deploy",
+    "migrate:status": "node scripts/run-backend-script.js migrate:status",
+    "verify:migration": "node scripts/run-backend-script.js verify:migration",
+    "postinstall": "node scripts/run-backend-script.js prisma:generate --skip-if-missing",
     "package:wordpress": "npm run package --workspace=@covenant-connect/wordpress-plugin"
   }
 }

--- a/scripts/run-backend-script.js
+++ b/scripts/run-backend-script.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+const { existsSync } = require('fs');
+const { join } = require('path');
+const { spawnSync } = require('child_process');
+
+const args = process.argv.slice(2);
+const [scriptName, ...rest] = args;
+const skipIfMissing = rest.includes('--skip-if-missing');
+
+if (!scriptName) {
+  console.error('Error: expected a backend script name as the first argument.');
+  process.exit(1);
+}
+
+const backendPath = join(process.cwd(), 'apps', 'backend');
+
+if (!existsSync(backendPath)) {
+  const message = 'Backend workspace not found at "apps/backend".';
+  if (skipIfMissing) {
+    console.log(`Skipping backend script "${scriptName}": ${message}`);
+    process.exit(0);
+  }
+
+  console.error(`Cannot run backend script "${scriptName}": ${message}`);
+  process.exit(1);
+}
+
+const result = spawnSync(
+  'npm',
+  ['--workspace', '@covenant-connect/backend', 'run', scriptName, ...rest.filter((arg) => arg !== '--skip-if-missing')],
+  {
+    stdio: 'inherit',
+    env: process.env,
+  }
+);
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- replace root npm scripts that target the backend workspace with a helper that invokes npm with workspace context
- add a Node helper script that skips gracefully when the backend workspace is absent, allowing frontend-only installs (e.g. Docker builds) to proceed

## Testing
- node scripts/run-backend-script.js prisma:generate --skip-if-missing

------
https://chatgpt.com/codex/tasks/task_e_68d4c0dda6cc8333992542176d64e28b